### PR TITLE
Update helm charts for Release 2.4

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -39,8 +39,14 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: added
+      description: containsSecurityUpdates and podSecurityContext can be defined for penpot-frontend.
+    - kind: added
+      description: Allow to run in a Openshift Container Platform.
     - kind: changed
       description: Bump Penpot images to 2.3.3.
+    - kind: changed
+      description: Change penpot-frontend service port to 8080.
 dependencies:
   - name: postgresql
     version: 15.x.x  # appVersion >= 16.2.0

--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-version: 0.5.0  # Chart version
-appVersion: "2.3.3"  # Penpot version
+version: 0.6.0  # Chart version
+appVersion: "2.4.0"  # Penpot version
 type: application
 name: penpot
 description: Helm chart for Penpot, the Open Source design and prototyping platform.
@@ -39,19 +39,26 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: added
-      description: containsSecurityUpdates and podSecurityContext can be defined for penpot-frontend.
-    - kind: added
-      description: Allow to run in a Openshift Container Platform.
     - kind: changed
-      description: Bump Penpot images to 2.3.3.
+      description: Bump Penpot images to 2.4.0.
     - kind: changed
       description: Change penpot-frontend service port to 8080.
     - kind: added
-      description: config.internalResolver sets PENPOT_INTERNAL_RESOLVER to the frontend deployment.
+      description: Add autoFileSnapshot configuration
+    - kind: added
+      description: containsSecurityUpdates and podSecurityContext can be defined for penpot-frontend.
+    - kind: added
+      description: Allow to run in a Openshift Container Platform. Thanks to @alverad-katsuro.
+      links:
+        - name: GitHub PR #9
+          url: https://github.com/penpot/penpot-helm/pull/9
+    - kind: added
+      description: config.internalResolver sets PENPOT_INTERNAL_RESOLVER to the frontend deployment. Thanks to @vipinjn24.
       links:
         - name: Github Issue #12
           url: https://github.com/penpot/penpot-helm/issues/12
+        - name: GitHub PR #13
+          url: https://github.com/penpot/penpot-helm/pull/13
 dependencies:
   - name: postgresql
     version: 15.x.x  # appVersion >= 16.2.0

--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -47,6 +47,11 @@ annotations:
       description: Bump Penpot images to 2.3.3.
     - kind: changed
       description: Change penpot-frontend service port to 8080.
+    - kind: added
+      description: config.internalResolver sets PENPOT_INTERNAL_RESOLVER to the frontend deployment.
+      links:
+        - name: Github Issue #12
+          url: https://github.com/penpot/penpot-helm/issues/12
 dependencies:
   - name: postgresql
     version: 15.x.x  # appVersion >= 16.2.0

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -1,6 +1,6 @@
 # penpot
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: 2.3.3](https://img.shields.io/badge/AppVersion-2.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart for Penpot, the Open Source design and prototyping platform.
 
@@ -72,6 +72,8 @@ helm install my-release -f values.yaml penpot/penpot
 | config.assets.s3.secretKeys.endpointURIKey | string | `""` | The S3 endpoint URI to use from an existing secret. |
 | config.assets.s3.secretKeys.secretAccessKey | string | `""` | The S3 secret access key to use from an existing secret. |
 | config.assets.storageBackend | string | `"assets-fs"` | The storage backend for assets to use. Use `assets-fs` for filesystem, and `assets-s3` for S3. |
+| config.autoFileSnapshot.every | int | `5` | How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable. |
+| config.autoFileSnapshot.timeout | string | `"3h"` | If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable. |
 | config.flags | string | `"enable-registration enable-login-with-password disable-email-verification enable-smtp"` | The feature flags to enable. Check [the official docs](https://help.penpot.app/technical-guide/configuration/) for more info. |
 | config.internalResolver | string | `""` | Add custom resolver for frontend. e.g. 192.168.1.1 |
 | config.postgresql.database | string | `"penpot"` | The PostgreSQL database to use. |
@@ -154,7 +156,7 @@ helm install my-release -f values.yaml penpot/penpot
 | backend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | backend.image.repository | string | `"penpotapp/backend"` | The Docker repository to pull the image from. |
-| backend.image.tag | string | `"2.3.3"` | The image tag to use. |
+| backend.image.tag | string | `"2.4.0"` | The image tag to use. |
 | backend.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | backend.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | backend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the backend pods. |
@@ -180,7 +182,7 @@ helm install my-release -f values.yaml penpot/penpot
 | frontend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | frontend.image.repository | string | `"penpotapp/frontend"` | The Docker repository to pull the image from. |
-| frontend.image.tag | string | `"2.3.3"` | The image tag to use. |
+| frontend.image.tag | string | `"2.4.0"` | The image tag to use. |
 | frontend.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | frontend.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the frontend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | frontend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the frontend pods. |
@@ -206,7 +208,7 @@ helm install my-release -f values.yaml penpot/penpot
 | exporter.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | exporter.image.imagePullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | exporter.image.repository | string | `"penpotapp/exporter"` | The Docker repository to pull the image from. |
-| exporter.image.tag | string | `"2.3.3"` | The image tag to use. |
+| exporter.image.tag | string | `"2.4.0"` | The image tag to use. |
 | exporter.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | exporter.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the exporter pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | exporter.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the exporter pods. |

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -175,7 +175,7 @@ helm install my-release -f values.yaml penpot/penpot
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | frontend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| frontend.containerSecurityContext | object | `{}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | frontend.image.repository | string | `"penpotapp/frontend"` | The Docker repository to pull the image from. |
@@ -187,12 +187,12 @@ helm install my-release -f values.yaml penpot/penpot
 | frontend.pdb.minAvailable | int,string | `nil` | The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%"). |
 | frontend.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
 | frontend.podLabels | object | `{}` | An optional map of labels to be applied to the controller Pods |
-| frontend.podSecurityContext | object | `{}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| frontend.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.replicaCount | int | `1` | The number of replicas to deploy. |
 | frontend.resources | object | `{"limits":{},"requests":{}}` | Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
 | frontend.resources.limits | object | `{}` | The resources limits for the Penpot frontend containers |
 | frontend.resources.requests | object | `{}` | The requested resources for the Penpot frontend containers |
-| frontend.service.port | int | `80` | The service port to use. |
+| frontend.service.port | int | `8080` | The service port to use. |
 | frontend.service.type | string | `"ClusterIP"` | The service type to create. |
 | frontend.tolerations | list | `[]` | Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
 
@@ -251,14 +251,25 @@ helm install my-release -f values.yaml penpot/penpot
 | ingress.path | string | `"/"` | Root path for every hosts. |
 | ingress.tls | list | `[]` | Array style TLS secrets for the (frontend) ingress crontroller. E.g. tls:   - secretName: penpot.example.com-tls     hosts:       - penpot.example.com |
 
+### Reute (for OpenShift Container Platform)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| route.annotations | object | `{}` | An optional map of annotations to be applied to the route. |
+| route.enabled | bool | `false` | Enable Openshift/OKD Route. Check [the official doc](https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html). When it is enabled, all fsGroup and runAsUser must be changed to null. |
+| route.host | string | `"penpot.example.com"` | The default external hostname to access to the penpot app. |
+| route.path | string | `nil` | Define a path to use Path-based routes. |
+| route.tls | object | `{}` | A Map with TLS configuration for the route. E.g. tls:   terminationType: edge   terminationPolicy: Redirect |
+| route.wildcardPolicy | string | `"None"` | Define the wildcard policy (None, Subdomain, ...) |
+
 ### PostgreSQL
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| postgresql | object | `{"auth":{"database":"penpot","password":"penpot","username":"penpot"}}` | PostgreSQL configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/postgresql)) |
 | postgresql.auth.database | string | `"penpot"` | Name for a custom database to create. |
 | postgresql.auth.password | string | `"penpot"` | Password for the custom user to create. |
 | postgresql.auth.username | string | `"penpot"` | Name for a custom user to create. |
+| postgresql.global.compatibility.openshift.adaptSecurityContext | string | `"auto"` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) |
 
 > **NOTE**: You can use more parameters according to the [PostgreSQL oficial documentation](https://artifacthub.io/packages/helm/bitnami/postgresql#parameters).
 
@@ -266,8 +277,8 @@ helm install my-release -f values.yaml penpot/penpot
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| redis | object | `{"auth":{"enabled":false}}` | Redis configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/redis)) |
 | redis.auth.enabled | bool | `false` | Whether to enable password authentication. |
+| redis.global.compatibility.openshift.adaptSecurityContext | string | `"auto"` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) |
 
 > **NOTE**: You can use more parameters according to the [Redis oficial documentation](https://artifacthub.io/packages/helm/bitnami/redis#parameters).
 

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -73,6 +73,7 @@ helm install my-release -f values.yaml penpot/penpot
 | config.assets.s3.secretKeys.secretAccessKey | string | `""` | The S3 secret access key to use from an existing secret. |
 | config.assets.storageBackend | string | `"assets-fs"` | The storage backend for assets to use. Use `assets-fs` for filesystem, and `assets-s3` for S3. |
 | config.flags | string | `"enable-registration enable-login-with-password disable-email-verification enable-smtp"` | The feature flags to enable. Check [the official docs](https://help.penpot.app/technical-guide/configuration/) for more info. |
+| config.internalResolver | string | `""` | Add custom resolver for frontend. e.g. 192.168.1.1 |
 | config.postgresql.database | string | `"penpot"` | The PostgreSQL database to use. |
 | config.postgresql.existingSecret | string | `""` | The name of an existing secret. |
 | config.postgresql.host | string | `""` | The PostgreSQL host to connect to. Empty to use dependencies. |

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -64,6 +64,7 @@ helm install my-release -f values.yaml penpot/{{ template "chart.name" . }}
     (hasPrefix "exporter" .Key)
     (hasPrefix "persistence" .Key)
     (hasPrefix "ingress" .Key)
+    (hasPrefix "route" .Key)
     (hasPrefix "postgresql" .Key)
     (hasPrefix "redis" .Key)
   ) }}
@@ -133,6 +134,17 @@ helm install my-release -f values.yaml penpot/{{ template "chart.name" . }}
 |-----|------|---------|-------------|
 {{- range .Values }}
   {{- if hasPrefix "ingress" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+
+### Reute (for OpenShift Container Platform)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "route" .Key }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -363,6 +363,11 @@ spec:
               value: {{ .Values.config.providers.ldap.attributesPhoto | quote }}
             {{- end }}
           {{- end }}
+            # Auto file snapshot settings
+            - name: PENPOT_AUTO_FILE_SNAPSHOT_EVERY
+              value: {{ .Values.config.autoFileSnapshot.every | quote }}
+            - name: PENPOT_AUTO_FILE_SNAPSHOT_TIMEOUT
+              value: {{ .Values.config.autoFileSnapshot.timeout | quote }}
           volumeMounts:
             - mountPath: /opt/data/assets
               name: app-data

--- a/charts/penpot/templates/backend-service.yml
+++ b/charts/penpot/templates/backend-service.yml
@@ -6,11 +6,11 @@ metadata:
   labels:
     {{- include "penpot.labels" . | nindent 4 }}
 spec:
-  selector:
-    {{- include "penpot.backendSelectorLabels" . | nindent 4 }}
   type: {{ .Values.backend.service.type }}
   ports:
     - port: {{ .Values.backend.service.port }}
       targetPort: {{ .Values.backend.service.port }}
       protocol: TCP
       name: http
+  selector:
+    {{- include "penpot.backendSelectorLabels" . | nindent 4 }}

--- a/charts/penpot/templates/frontend-deployment.yml
+++ b/charts/penpot/templates/frontend-deployment.yml
@@ -53,6 +53,14 @@ spec:
               value: {{ print "http://" (include "penpot.fullname" .) "-backend:" .Values.backend.service.port }}
             - name: PENPOT_EXPORTER_URI
               value: {{ print "http://" (include "penpot.fullname" .) "-exporter:" .Values.exporter.service.port }}
+            - name: PENPOT_INTERNAL_RESOLVER
+              {{- if not .Values.config.internalResolver }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+              {{- else }}
+              value: {{ .Values.config.internalResolver | quote }}
+              {{- end }}
           volumeMounts:
             - mountPath: /opt/data/assets
               name: app-data

--- a/charts/penpot/templates/frontend-service.yml
+++ b/charts/penpot/templates/frontend-service.yml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.frontend.service.type }}
   ports:
     - port: {{ .Values.frontend.service.port }}
-      targetPort: http
+      targetPort: {{ .Values.frontend.service.port }}
       protocol: TCP
       name: http
   selector:

--- a/charts/penpot/templates/route.yml
+++ b/charts/penpot/templates/route.yml
@@ -1,0 +1,30 @@
+{{- if .Values.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "penpot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  host: {{ .Values.route.host }}
+  path: {{ .Values.route.path }}
+  to:
+    kind: Service
+    name: {{ include "penpot.fullname" . }}
+  port:
+    targetPort: http
+  {{- with .Values.route.tls }}
+  tls:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{ end }}
+  wildcardPolicy: {{ .Values.route.wildcardPolicy | quote }}
+{{- end }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -400,7 +400,7 @@ frontend:
     type: ClusterIP
     # -- The service port to use.
     # @section -- Frontend parameters
-    port: 80
+    port: 8080
   # -- An optional map of annotations to be applied to the controller Deployment
   # @section -- Frontend parameters
   deploymentAnnotations: {}
@@ -412,10 +412,18 @@ frontend:
   podAnnotations: {}
   # -- Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   # @section -- Frontend parameters
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 1001
   # -- Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
   # @section -- Frontend parameters
-  containerSecurityContext: {}
+  containerSecurityContext:
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - all
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
   # -- Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
   # @section -- Frontend parameters
   affinity: {}
@@ -522,7 +530,6 @@ exporter:
     # @section -- Exporter parameters
     maxUnavailable:
 
-# @section -- Persistence parameters
 persistence:
   assets:
     # -- Enable assets persistence using Persistent Volume Claims.
@@ -599,9 +606,39 @@ ingress:
   # @section -- Ingress parameters
   tls: []
 
-# -- PostgreSQL configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/postgresql))
-# @section -- PostgreSQL Dependencie parameters
+route:
+  # -- Enable Openshift/OKD Route. Check [the official doc](https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html). When it is enabled, all fsGroup and runAsUser must be changed to null.
+  # @section -- Route parameters
+  enabled: false
+  # -- An optional map of annotations to be applied to the route.
+  # @section -- Route parameters
+  annotations: {}
+  # -- The default external hostname to access to the penpot app.
+  # @section -- Route parameters
+  host: penpot.example.com
+  # -- Define a path to use Path-based routes.
+  # @section -- Route parameters
+  path: null
+  # -- A Map with TLS configuration for the route.
+  # E.g.
+  # tls:
+  #   terminationType: edge
+  #   terminationPolicy: Redirect
+  # @section -- Route parameters
+  tls: {}
+  # -- Define the wildcard policy (None, Subdomain, ...)
+  # @section -- Route parameters
+  wildcardPolicy: None
+
+# PostgreSQL configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/postgresql))
 postgresql:
+  global:
+    compatibility:
+      openshift:
+        # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+        # @section -- PostgreSQL Dependencie parameters
+        adaptSecurityContext: 'auto'
+
   auth:
     # -- Name for a custom user to create.
     # @section -- PostgreSQL Dependencie parameters
@@ -613,9 +650,14 @@ postgresql:
     # @section -- PostgreSQL Dependencie parameters
     database: "penpot"
 
-# -- Redis configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/redis))
-# @section -- Redis Dependencie parameters
+# Redis configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/redis))
 redis:
+  global:
+    compatibility:
+      openshift:
+        # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+        # @section -- Redis Dependencie parameters
+        adaptSecurityContext: 'auto'
   auth:
     # -- Whether to enable password authentication.
     # @section -- Redis Dependencie parameters

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -49,6 +49,9 @@ config:
   # -- Whether to enable sending of anonymous telemetry data.
   # @section -- Configuration parameters
   telemetryEnabled: true
+  # -- Add custom resolver for frontend. e.g. 192.168.1.1
+  # @section -- Configuration parameters
+  internalResolver: ""
 
   postgresql:
     # -- The PostgreSQL host to connect to. Empty to use dependencies.

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -308,6 +308,14 @@ config:
       # @section -- Configuration parameters
       oidcClientSecretKey: ""
 
+  autoFileSnapshot:
+    # -- How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
+    # @section -- Configuration parameters
+    every: 5  # Every 5 changes
+    # -- If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
+    # @section -- Configuration parameters
+    timeout: "3h"
+
 backend:
   image:
     # -- The Docker repository to pull the image from.
@@ -315,7 +323,7 @@ backend:
     repository: penpotapp/backend
     # -- The image tag to use.
     # @section -- Backend parameters
-    tag: 2.3.3
+    tag: 2.4.0
     # -- The image pull policy to use.
     # @section -- Backend parameters
     pullPolicy: IfNotPresent
@@ -390,7 +398,7 @@ frontend:
     repository: penpotapp/frontend
     # -- The image tag to use.
     # @section -- Frontend parameters
-    tag: 2.3.3
+    tag: 2.4.0
     # -- The image pull policy to use.
     # @section -- Frontend parameters
     pullPolicy: IfNotPresent
@@ -465,7 +473,7 @@ exporter:
     repository: penpotapp/exporter
     # -- The image tag to use.
     # @section -- Exporter parameters
-    tag: 2.3.3
+    tag: 2.4.0
     # -- The image pull policy to use.
     # @section -- Exporter parameters
     imagePullPolicy: IfNotPresent

--- a/devel/README.md
+++ b/devel/README.md
@@ -54,7 +54,7 @@ pre-commit install --install-hooks -f
 > [!TIP]
 > if you disable ingress, you can exposing the app in the port 8888 with:
 > ```shell
-> kubectl port-forward service/penpot 8888:80
+> kubectl port-forward service/penpot 8888:8080
 > ```
 
 - Stop and delete cluster.

--- a/devel/kind.config.yml
+++ b/devel/kind.config.yml
@@ -10,6 +10,9 @@ nodes:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
   extraPortMappings:
+  - containerPort: 8080
+    hostPort: 8080
+    protocol: TCP
   - containerPort: 80
     hostPort: 80
     protocol: TCP

--- a/devel/penpot.values.yaml
+++ b/devel/penpot.values.yaml
@@ -1,3 +1,4 @@
+---
 ## Default values for Penpot (local setup for development purpose)
 global:
   postgresqlEnabled: true


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95c648d5-a0c8-4ee0-a015-0788202b38e1)

This PR:
- [x] update helm charts to add new flag regarding auto-file-snapshot
- [x] prepare to use the new unprivileged nginx image, containsSecurityUpdates and podSecurityContext can be defined for penpot-frontend.
- [x] allow running in a OpenShift Container Platform
- [x] make PENPOT_INTERNAL_RESOLVER configurable for the frontend deployment.