### PR TITLE
feat: allow ldap password via secret

### DIFF
--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -100,7 +100,7 @@ helm install my-release -f values.yaml penpot/penpot
 | config.providers.ldap.attributesPhoto | string | `"jpegPhoto"` | The LDAP attributes photo format to use. |
 | config.providers.ldap.attributesUsername | string | `"uid"` | The LDAP attributes username to use. |
 | config.providers.ldap.baseDN | string | `"ou=people,dc=planetexpress,dc=com"` | The LDAP base DN to use. |
-| config.providers.ldap.bindDN | string | `"cn=admin,dc=planetexpress,dc=com"` | The LDAP bind DN to use. |
+| config.providers.ldap.bindDN | string | `"uid=admin,ou=people,dc=planetexpress,dc=com"` | The LDAP bind DN to use. |
 | config.providers.ldap.bindPassword | string | `"GoodNewsEveryone"` | The LDAP bind password to use. |
 | config.providers.ldap.enabled | bool | `false` | Whether to enable LDAP configuration. To enable LDAP, also add `enable-login-with-ldap` to the flags. |
 | config.providers.ldap.host | string | `"ldap"` | The LDAP host to use. |
@@ -126,6 +126,7 @@ helm install my-release -f values.yaml penpot/penpot
 | config.providers.secretKeys.gitlabClientSecretKey | string | `""` | The GitLab client secret key to use from an existing secret. |
 | config.providers.secretKeys.googleClientIDKey | string | `""` | The Google client ID key to use from an existing secret. |
 | config.providers.secretKeys.googleClientSecretKey | string | `""` | The Google client secret key to use from an existing secret. |
+| config.providers.secretKeys.ldapBindPasswordKey | string | `""` | The LDAP admin bind password to use from an exsiting secret |
 | config.providers.secretKeys.oidcClientIDKey | string | `""` | The OpenID Connect client ID key to use from an existing secret. |
 | config.providers.secretKeys.oidcClientSecretKey | string | `""` | The OpenID Connect client secret key to use from an existing secret. |
 | config.publicUri | string | `"http://penpot.example.com"` | The public domain to serve Penpot on. **IMPORTANT:** Set `disable-secure-session-cookies` in the flags if you plan on serving it on a non HTTPS domain. |
@@ -154,6 +155,7 @@ helm install my-release -f values.yaml penpot/penpot
 | backend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | backend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | backend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
+| backend.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | backend.image.repository | string | `"penpotapp/backend"` | The Docker repository to pull the image from. |
 | backend.image.tag | string | `"2.4.3"` | The image tag to use. |

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -315,8 +315,8 @@ spec:
               value: {{ .Values.config.providers.oidc.userInfoSource | quote }}
             {{- end }}
           {{- end }}
-            # LDAP provider settings
           {{- if .Values.config.providers.ldap.enabled }}
+            # LDAP provider settings
             {{- if .Values.config.providers.ldap.host }}
             - name: PENPOT_LDAP_HOST
               value: {{ .Values.config.providers.ldap.host | quote }}
@@ -341,7 +341,13 @@ spec:
             - name: PENPOT_LDAP_BIND_DN
               value: {{ .Values.config.providers.ldap.bindDN | quote }}
             {{- end }}
-            {{- if .Values.config.providers.ldap.bindPassword }}
+            {{- if .Values.config.providers.secretKeys.ldapBindPasswordKey }}
+            - name: PENPOT_LDAP_BIND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.providers.existingSecret }}
+                  key: {{ .Values.config.providers.secretKeys.ldapBindPasswordKey }}
+            {{- else if .Values.config.providers.ldap.bindPassword }}
             - name: PENPOT_LDAP_BIND_PASSWORD
               value: {{ .Values.config.providers.ldap.bindPassword | quote }}
             {{- end }}
@@ -371,6 +377,9 @@ spec:
               value: {{ .Values.config.autoFileSnapshot.every | quote }}
             - name: PENPOT_AUTO_FILE_SNAPSHOT_TIMEOUT
               value: {{ .Values.config.autoFileSnapshot.timeout | quote }}
+          {{- with .Values.backend.extraEnvs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /opt/data/assets
               name: app-data

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -56,7 +56,7 @@ config:
   postgresql:
     # -- The PostgreSQL host to connect to. Empty to use dependencies.
     # @section -- Configuration parameters
-    host: ""  # Ex.: "postgresql.penpot.svc.cluster.local"
+    host: "" # Ex.: "postgresql.penpot.svc.cluster.local"
     # -- The PostgreSQL host port to use.
     # @section -- Configuration parameters
     port: 5432
@@ -83,7 +83,7 @@ config:
   redis:
     # -- The Redis host to connect to. Empty to use dependencies
     # @section -- Configuration parameters
-    host: ""  # Ex.: "redis-headless.penpot.svc.cluster.local"
+    host: "" # Ex.: "redis-headless.penpot.svc.cluster.local"
     # -- The Redis host port to use.
     # @section -- Configuration parameters
     port: 6379
@@ -260,7 +260,7 @@ config:
       baseDN: "ou=people,dc=planetexpress,dc=com"
       # -- The LDAP bind DN to use.
       # @section -- Configuration parameters
-      bindDN: "cn=admin,dc=planetexpress,dc=com"
+      bindDN: "uid=admin,ou=people,dc=planetexpress,dc=com"
       # -- The LDAP bind password to use.
       # @section -- Configuration parameters
       bindPassword: "GoodNewsEveryone"
@@ -307,11 +307,14 @@ config:
       # -- The OpenID Connect client secret key to use from an existing secret.
       # @section -- Configuration parameters
       oidcClientSecretKey: ""
+      # -- The LDAP admin bind password to use from an exsiting secret
+      # @section -- Configuration parameters
+      ldapBindPasswordKey: ""
 
   autoFileSnapshot:
     # -- How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
     # @section -- Configuration parameters
-    every: 5  # Every 5 changes
+    every: 5 # Every 5 changes
     # -- If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
     # @section -- Configuration parameters
     timeout: "3h"
@@ -390,6 +393,9 @@ backend:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Backend parameters
     maxUnavailable:
+  # -- Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
+  # @section -- Backend parameters
+  extraEnvs: []
 
 frontend:
   image:
@@ -648,7 +654,7 @@ postgresql:
       openshift:
         # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         # @section -- PostgreSQL Dependencie parameters
-        adaptSecurityContext: 'auto'
+        adaptSecurityContext: "auto"
 
   auth:
     # -- Name for a custom user to create.
@@ -668,7 +674,7 @@ redis:
       openshift:
         # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         # @section -- Redis Dependencie parameters
-        adaptSecurityContext: 'auto'
+        adaptSecurityContext: "auto"
   auth:
     # -- Whether to enable password authentication.
     # @section -- Redis Dependencie parameters

--- a/scripts/cluster_create.sh
+++ b/scripts/cluster_create.sh
@@ -4,7 +4,7 @@
 kind create cluster --name penpot-cluster --config devel/kind.config.yml
 
 # Create a namespace for Penpot
-kubectl apply -f devel/penpot-namespace.yml
+kubectl apply -f devel/penpot-namespace.yml --context=kind-penpot-cluster
 kubectl config set-context penpot --namespace=penpot --cluster=kind-penpot-cluster --user=kind-penpot-cluster
 kubectl config use-context penpot
 


### PR DESCRIPTION
When going to self host penpot using the helm chart I saw that for the LDAP provider the only way to give it a password was by including it directly on the values file. I've made some updates here to allow us to pull that information from a secret in the same fashion as the other providers.

When setting up LDAP I also experienced an issue with the default bindDN where just using the "cn" value caused an error stating it was invalid. I updated the default value to align more with what I got working using [lldap](https://github.com/lldap/lldap).

Outside of the LDAP updates I also made a small tweak to the local script to make sure the penpot namespace creation only applies to the cluster created via kind and I provided the ability to specify any other kind of `env` value to the backend deployment. Mainly for situations where the helm chart may not allow us to say, set an env from a secret, it could then be facilitated via the `extraEnv` field. Like in the LDAP situation, if `extraEnv` was already present I could just set the password using that theoretically.

Hopefully this helps someone, but let me know if I should change/update anything or if it just isn't something that can be worked in.

Relevant updates
- Allow setting ldap bind password using the existing secret flow
- Fix issue where the default bindDN states it is an invalid format when being utilized
- Moved LDAP comment inside LDAP enabled logic so it doesn't always print in the generated manifest

Other updates:
- Allow setting adhoc environment variables outside the format provided via the helm chart
- Ensure penpot namespace is created in cluster created by kind (make sure it doesn't run on a cluster already configured locally with kubectl)
- YAML linter also fixed a couple issues