### PR TITLE
feat: allow secrets for all postgres values

### DIFF
--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -81,7 +81,10 @@ helm install my-release -f values.yaml penpot/penpot
 | config.postgresql.host | string | `""` | The PostgreSQL host to connect to. Empty to use dependencies. |
 | config.postgresql.password | string | `"penpot"` | The database password to use. |
 | config.postgresql.port | int | `5432` | The PostgreSQL host port to use. |
+| config.postgresql.secretKeys.databaseKey | string | `""` | The database key to use from an existing secret. |
+| config.postgresql.secretKeys.hostKey | string | `""` | The host key to use from an existing secret. |
 | config.postgresql.secretKeys.passwordKey | string | `""` | The password key to use from an existing secret. |
+| config.postgresql.secretKeys.portKey | string | `""` | The port key to use from an existing secret. |
 | config.postgresql.secretKeys.usernameKey | string | `""` | The username key to use from an existing secret. |
 | config.postgresql.username | string | `"penpot"` | The database username to use. |
 | config.providers.existingSecret | string | `""` | The name of an existing secret to use. |

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -61,31 +61,60 @@ spec:
               value: {{ .Values.config.telemetryEnabled | quote }}
             - name: PENPOT_TELEMETRY_REFERER
               value: kubernetes
+            {{- with .Values.config.postgresql }}
             # PosgreSQL connection settings
-            - name: PENPOT_DATABASE_URI
-              {{- if .Values.config.postgresql.host }}
-              value: "postgresql://{{ .Values.config.postgresql.host }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
+            - name: PENPOT_DATABASE_HOST
+              {{- if .secretKeys.hostKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret }}
+                  key: {{ .secretKeys.hostKey }}
               {{- else }}
-              value: {{ print "postgresql://" (include "penpot.fullname" .) "-postgresql:" .Values.config.postgresql.port "/" .Values.config.postgresql.database }}
+              value: {{ if .host }}
+                {{- .host }}
+              {{- else }}
+                {{- printf "%s-%s" (include "penpot.fullname" $) "postgresql" }}
               {{- end }}
+              {{- end }}
+            - name: PENPOT_DATABASE_PORT
+              {{- if .secretKeys.portKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret }}
+                  key: {{ .secretKeys.portKey }}
+              {{- else }}
+              value: {{ .port | quote }}
+              {{- end }}
+            - name: PENPOT_DATABASE_NAME
+              {{- if .secretKeys.databaseKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .existingSecret }}
+                  key: {{ .secretKeys.databaseKey }}
+              {{- else }}
+              value: {{ .database | quote }}
+              {{- end }}
+            - name: PENPOT_DATABASE_URI
+              value: "postgresql://$(PENPOT_DATABASE_HOST):$(PENPOT_DATABASE_PORT)/$(PENPOT_DATABASE_NAME)"
             - name: PENPOT_DATABASE_USERNAME
-              {{- if not .Values.config.postgresql.secretKeys.usernameKey }}
-              value: {{ .Values.config.postgresql.username | quote }}
+              {{- if not .secretKeys.usernameKey }}
+              value: {{ .username | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.postgresql.existingSecret }}
-                  key: {{ .Values.config.postgresql.secretKeys.usernameKey }}
+                  name: {{ .existingSecret }}
+                  key: {{ .secretKeys.usernameKey }}
               {{- end }}
             - name: PENPOT_DATABASE_PASSWORD
-              {{- if not .Values.config.postgresql.secretKeys.passwordKey }}
-              value: {{ .Values.config.postgresql.password | quote }}
+              {{- if not .secretKeys.passwordKey }}
+              value: {{ .password | quote }}
               {{- else }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.config.postgresql.existingSecret }}
-                  key: {{ .Values.config.postgresql.secretKeys.passwordKey }}
+                  name: {{ .existingSecret }}
+                  key: {{ .secretKeys.passwordKey }}
               {{- end }}
+            {{- end }}
             # Redis connection settings
             - name: PENPOT_REDIS_URI
               {{- if .Values.config.redis.host }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -56,7 +56,7 @@ config:
   postgresql:
     # -- The PostgreSQL host to connect to. Empty to use dependencies.
     # @section -- Configuration parameters
-    host: ""  # Ex.: "postgresql.penpot.svc.cluster.local"
+    host: "" # Ex.: "postgresql.penpot.svc.cluster.local"
     # -- The PostgreSQL host port to use.
     # @section -- Configuration parameters
     port: 5432
@@ -73,6 +73,15 @@ config:
     # @section -- Configuration parameters
     existingSecret: ""
     secretKeys:
+      # -- The host key to use from an existing secret.
+      # @section -- Configuration parameters
+      hostKey: ""
+      # -- The port key to use from an existing secret.
+      # @section -- Configuration parameters
+      portKey: ""
+      # -- The database key to use from an existing secret.
+      # @section -- Configuration parameters
+      databaseKey: ""
       # -- The username key to use from an existing secret.
       # @section -- Configuration parameters
       usernameKey: ""
@@ -83,7 +92,7 @@ config:
   redis:
     # -- The Redis host to connect to. Empty to use dependencies
     # @section -- Configuration parameters
-    host: ""  # Ex.: "redis-headless.penpot.svc.cluster.local"
+    host: "" # Ex.: "redis-headless.penpot.svc.cluster.local"
     # -- The Redis host port to use.
     # @section -- Configuration parameters
     port: 6379
@@ -311,7 +320,7 @@ config:
   autoFileSnapshot:
     # -- How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
     # @section -- Configuration parameters
-    every: 5  # Every 5 changes
+    every: 5 # Every 5 changes
     # -- If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
     # @section -- Configuration parameters
     timeout: "3h"
@@ -648,7 +657,7 @@ postgresql:
       openshift:
         # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         # @section -- PostgreSQL Dependencie parameters
-        adaptSecurityContext: 'auto'
+        adaptSecurityContext: "auto"
 
   auth:
     # -- Name for a custom user to create.
@@ -668,7 +677,7 @@ redis:
       openshift:
         # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         # @section -- Redis Dependencie parameters
-        adaptSecurityContext: 'auto'
+        adaptSecurityContext: "auto"
   auth:
     # -- Whether to enable password authentication.
     # @section -- Redis Dependencie parameters


### PR DESCRIPTION
When utilizing the [cloudnative-pg](https://cloudnative-pg.io/) operator the recommended flow for utilizing it is to spin up a new postgresql cluster for each service requesting a database. When doing this it creates secrets containing all the connection information an app needs to be able to connect to the new postgresql cluster including the host, port, username, password and database name.

To facilitate the flow recommended by cloudnative-pg and to facilitate just anyone wanting to specify all the postgres values as secrets I expanded on the existingSecret functionality to pull all possible postgresql configuration values for penpot and setting it to the relevant environment variables.

To facilitate this for the host, port and database values, since penpot is expecting a singular URI environment variable I am tossing three additional environment variables for the relevant host, port and database information. I am then referencing them when creating the URI environment variable. This allows me to concatenate the values from secrets into the URI format needed by penpot.

Hopefully this helps someone, but if there is anything that needs to be updated let me know!

Relevant Changes:
- Allow setting all possible postgres configuration values utilizing the existingSecret flow to support options like cloudnative-pg
- Utilized the `with` keyword in the postgresql section to reduce some of the duplication, let me know if this isn't preferred though

Misc Changes:
- YAML linter cleaned up some lines