### PR TITLE
feat: startup probe (#27)

### DIFF
--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -415,6 +415,8 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.backend.startupProbe | nindent 12 }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -407,6 +407,14 @@ backend:
     # -- The requested resources for the Penpot backend containers
     # @section -- Backend parameters
     requests: {}
+  # -- Startup probe for the Penpot backend containers. Tolerates up to 30 * 10 = 300 seconds = 5 Minutes. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)
+  # @section -- Backend parameters
+  startupProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    failureThreshold: 30
+    periodSeconds: 10
   # -- Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
   # @section -- Backend parameters
   pdb:


### PR DESCRIPTION
Prevents killing old Backend instances before the new one is ready during Rolling Updates.

Closes #27