### PR TITLE
Make assets dir persistent by default

### DIFF
--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -592,7 +592,7 @@ persistence:
   assets:
     # -- Enable assets persistence using Persistent Volume Claims.
     # @section -- Persistence parameters
-    enabled: false
+    enabled: true
     # -- Assets persistent Volume storage class.
     # If defined, storageClassName: <storageClass>.
     # If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.


### PR DESCRIPTION
This PR makes the assets directory persistent by default, as discussed in https://github.com/penpot/penpot-helm/issues/31.

In my opinion, this change is necessary, otherwise, users may become frustrated when the backend pod is restarted the first time and their assets are lost.

If you have a different opinion, I’m happy to discuss it :)