### PR TITLE
feat: Add the secret key to the exporter environment

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -39,6 +39,8 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: changed
+      description: Add the secret key to the exporter service
 dependencies:
   - name: postgresql
     version: 15.5.38 # default appVersion 16.4.0

--- a/charts/penpot/templates/exporter-deployment.yml
+++ b/charts/penpot/templates/exporter-deployment.yml
@@ -47,6 +47,15 @@ spec:
           env:
             - name: PENPOT_PUBLIC_URI
               value: {{ print "http://" (include "penpot.fullname" .) ":" .Values.frontend.service.port }}
+            - name: PENPOT_SECRET_KEY
+              {{- if not .Values.config.secretKeys.apiSecretKey }}
+              value: {{ .Values.config.apiSecretKey | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.existingSecret }}
+                  key: {{ .Values.config.secretKeys.apiSecretKey }}
+              {{- end }}
             - name: PENPOT_REDIS_URI
               {{- if not .Values.config.redis.secretKeys.redisUriKey }}
                 {{- if .Values.config.redis.host }}


### PR DESCRIPTION
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2pmd3FoMnlqY3BlanBlODhzN3dleXBuNW1qZ2h5b2hrZHJpNGJ5YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/weBRxESIuCwn82bLc8/giphy.gif)

This PR add the PENPOT_SECRET_KEY to the exporter service, as it was done in the [docker-compose](https://github.com/penpot/penpot/pull/7746/commits/4546fb6e4ebf00b7817ebca2b5db33c0c8590186)