### PR TITLE
chore: migrate postgres from bitnami chart to cloudnative-pg operator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
 repos:
   - repo: https://github.com/norwoodj/helm-docs
-    rev: v1.13.1
+    rev: v1.14.2
     hooks:
       - id: helm-docs-built
         args:
@@ -15,13 +19,13 @@ repos:
           - --template-files=README.md.gotmpl
 
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23
+    rev: v0.1.30
     hooks:
       - id: helmlint
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: []
+        args: [--verbose]

--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-version: 0.33.0-unreleased # Chart version
-appVersion: "2.12.1"  # Penpot version
+version: 0.34.0-unreleased # Chart version
+appVersion: "2.13.0"  # Penpot version
 type: application
 name: penpot
 description: Helm chart for Penpot, the Open Source design and prototyping platform.
@@ -39,6 +39,14 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: added
+      description: Add support for CloudNativePG (CNPG) as a PostgreSQL backend.
+    - kind: added
+      description: Introduce new global configuration flags to control PostgreSQL backend selection (global.cnpg.enabled to deploy CNPG, global.cnpg.useAsPrimary to switch CNPG as primary, global.postgresqlEnabled to enable or disable Bitnami PostgreSQL).
+    - kind: changed
+      description: PostgreSQL backend selection logic now supports a migration mode where Bitnami PostgreSQL and CNPG can coexist before switching the primary database.
+    - kind: deprecated
+      description: Bitnami PostgreSQL is deprecated and will be supported for the next 3 chart releases only. Migration to CloudNativePG is manual and not performed automatically.
 dependencies:
   - name: postgresql
     version: 15.5.38 # default appVersion 16.4.0

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -1,6 +1,6 @@
 # penpot
 
-![Version: 0.33.0-unreleased](https://img.shields.io/badge/Version-0.33.0--unreleased-informational?style=flat-square) ![AppVersion: 2.12.1](https://img.shields.io/badge/AppVersion-2.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.34.0-unreleased](https://img.shields.io/badge/Version-0.34.0--unreleased-informational?style=flat-square) ![AppVersion: 2.13.0](https://img.shields.io/badge/AppVersion-2.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart for Penpot, the Open Source design and prototyping platform.
 
@@ -11,6 +11,24 @@ Penpot is the first **open-source** design tool for design and code collaboratio
 Penpot is available on browser and [self host](https://penpot.app/self-host). It’s web-based and works with open standards (SVG, CSS and HTML). And last but not least, it’s free!
 
 ## Installing the Chart
+
+### Prerequisite: CloudNativePG operator (required when using CNPG)
+
+To use CloudNativePG (CNPG) as PostgreSQL backend, your Kubernetes cluster must have the CloudNativePG operator installed (it provides the postgresql.cnpg.io CRDs). If it’s not installed, the chart will fail to create CNPG resources.
+
+Install CloudNativePG operator:
+
+```console
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+```
+The following command installs the CloudNativePG operator and its required Custom Resource Definitions (CRDs):
+
+```consola
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+  --namespace cnpg-system --create-namespace
+```
+### Install penpot
 
 To install the chart with the release name `my-release`:
 
@@ -23,7 +41,7 @@ You can customize the installation specify each parameter using the `--set key=v
 
 ```console
 helm install my-release \
-  --set global.postgresqlEnabled=true \
+  --set global.cnpg.enabled=true \
   --set global.valkeyEnabled=true \
   --set persistence.assets.enabled=true \
   penpot/penpot
@@ -108,6 +126,8 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | config.apiSecretKey | string | `"kmZ96pAxhTgk3HZvvBkPeVTspGBneKVLEpO_3ecORs_gwACENZ77z05zCe7skvPsQ3jI3QgkULQOWCuLjmjQsg"` | A random secret key needed for persistent user sessions. Generate with `python3 -c "import secrets; print(secrets.token_urlsafe(64))"` for example. |
 | config.autoFileSnapshot.every | int | `5` | How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable. |
 | config.autoFileSnapshot.timeout | string | `"3h"` | If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable. |
+| config.cnpg.enabled | bool | `false` | Enable CloudNativePG (CNPG) PostgreSQL cluster resources.::ex:Ex:E`:e` |
+| config.cnpg.useAsPrimary | bool | `false` | Use CNPG as the primary database for Penpot. When `true`, the backend connects to CNPG and reads DB credentials from the internal CNPG secret. When `false` and `global.cnpg.enabled=true`, CNPG is deployed in parallel (migration mode) while Penpot keeps using Bitnami PostgreSQL. |
 | config.existingSecret | string | `""` | The name of an existing secret. |
 | config.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to all the containers (frontend, backend and exporter) in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | config.fileDataBackend | string | `"legacy-db"` | Define the strategy (backend) for internal file data storage of Penpot. Use "legacy-db" (default) the current behaviour, "db" to use an specific table in the database (future default) and "storage" to use the predefined objects storage system (S3, file system,...) |
@@ -212,7 +232,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | backend.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | backend.image.repository | string | `"penpotapp/backend"` | The Docker repository to pull the image from. |
-| backend.image.tag | string | `"2.12.1"` | The image tag to use. |
+| backend.image.tag | string | `"2.13.0"` | The image tag to use. |
 | backend.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | backend.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | backend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the backend pods. |
@@ -243,7 +263,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | frontend.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the frontend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | frontend.image.repository | string | `"penpotapp/frontend"` | The Docker repository to pull the image from. |
-| frontend.image.tag | string | `"2.12.1"` | The image tag to use. |
+| frontend.image.tag | string | `"2.13.0"` | The image tag to use. |
 | frontend.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | frontend.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the frontend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | frontend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the frontend pods. |
@@ -273,7 +293,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | exporter.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | exporter.image.imagePullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
 | exporter.image.repository | string | `"penpotapp/exporter"` | The Docker repository to pull the image from. |
-| exporter.image.tag | string | `"2.12.1"` | The image tag to use. |
+| exporter.image.tag | string | `"2.13.0"` | The image tag to use. |
 | exporter.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | exporter.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the exporter pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
 | exporter.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the exporter pods. |
@@ -375,6 +395,77 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 > **NOTE**: You can use more parameters according to the [Redis oficial documentation](https://artifacthub.io/packages/helm/bitnami/redis#parameters).
 
 ## Upgrading
+
+### To 1.0.0
+
+Bitnami is changing the way its Helm charts are maintained and distributed, which impacts how PostgreSQL is deployed and managed in Kubernetes environments. As a result, Penpot is moving away from the Bitnami PostgreSQL chart and adopting **CloudNativePG (CNPG)** as its PostgreSQL operator.
+
+This allows Penpot to rely on a Kubernetes-native, actively maintained solution for PostgreSQL lifecycle management, backups, and replication.
+
+This change introduces new configuration flags and **requires a manual data migration** if you are upgrading an existing installation that previously used Bitnami PostgreSQL.
+
+Depending on your current setup, follow **one of the scenarios below**.
+
+#### Migrating from Bitnami PostgreSQL to CloudNativePG
+
+If your Penpot installation was previously using the Bitnami PostgreSQL Helm chart, the database data must be migrated to a new CloudNativePG cluster.
+
+⚠️ **MIGRATION IS A MANUAL AND SAFE PROCESS AND WILL NOT BE PERFORMED AUTOMATICALLY.**
+
+##### Step 1: Enable CloudNativePG (migration mode)
+
+First, deploy CloudNativePG **while keeping Bitnami PostgreSQL enabled**:
+
+```console
+helm upgrade --install penpot . -n penpot \
+  --set global.cnpg.enabled=true \
+  --set global.postgresqlEnabled=true \
+  --set global.valkeyEnabled=true
+```
+
+##### Step 2: Run the migration script
+
+Once CloudNativePG is available, run the migration script:
+```console
+./scripts/upgrade/1.0.0/migrate-bitnami-to-cnpg.sh
+```
+
+This script will:
+
+* Connect to the existing Bitnami PostgreSQL instance
+
+* Dump the current database
+
+* Restore the data into the CloudNativePG cluster
+
+* Output the final Helm command required to complete the migration
+
+##### Step 3: Switch CloudNativePG as primary database
+
+After the migration finishes successfully, execute the command provided by the script, for example:
+```console
+helm upgrade --install penpot . -n penpot \
+  --set global.cnpg.enabled=true \
+  --set global.cnpg.useAsPrimary=true \
+  --set global.postgresqlEnabled=false \
+  --set global.valkeyEnabled=true
+```
+
+Once this step is completed:
+
+* CloudNativePG becomes the primary PostgreSQL backend
+
+* Bitnami PostgreSQL is disabled
+
+* Penpot runs fully on CloudNativePG
+
+##### Important notes
+
+* Migration is never automatic
+
+* Penpot will not switch databases unless global.cnpg.useAsPrimary=true
+
+* Bitnami PostgreSQL is supported only for **the next 3 chart releases**
 
 ### To 0.29.0
 

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -104,6 +104,8 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.cnpgEnabled | bool | `false` | Enable CloudNativePG (CNPG) resources (new installations or migration mode). |
+| global.cnpgUseAsPrimary | bool | `false` | Use CNPG as the primary database for Penpot. When `true`, the backend connects to CNPG and reads DB credentials from the internal CNPG secret. When `false` and `global.cnpgEnabled=true`, CNPG is deployed in parallel (migration mode) while Penpot keeps using Bitnami PostgreSQL. |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names. E.g. imagePullSecrets:   - myRegistryKeySecretName |
 | global.postgresqlEnabled | bool | `false` | Whether to deploy the Bitnami PostgreSQL chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/postgresql) for configuration. |
 | global.redisEnabled | bool | `false` | Whether to deploy the Bitnami Redis chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/redis) for configuration. *DEPRECATION WARNING: Since Penpot 2.8, Penpot has migrated from Redis to Valkey. Although migration is recommended, Penpot will work seamlessly with compatible Redis versions.  |
@@ -126,8 +128,6 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | config.apiSecretKey | string | `"kmZ96pAxhTgk3HZvvBkPeVTspGBneKVLEpO_3ecORs_gwACENZ77z05zCe7skvPsQ3jI3QgkULQOWCuLjmjQsg"` | A random secret key needed for persistent user sessions. Generate with `python3 -c "import secrets; print(secrets.token_urlsafe(64))"` for example. |
 | config.autoFileSnapshot.every | int | `5` | How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable. |
 | config.autoFileSnapshot.timeout | string | `"3h"` | If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable. |
-| config.cnpg.enabled | bool | `false` | Enable CloudNativePG (CNPG) PostgreSQL cluster resources.::ex:Ex:E`:e` |
-| config.cnpg.useAsPrimary | bool | `false` | Use CNPG as the primary database for Penpot. When `true`, the backend connects to CNPG and reads DB credentials from the internal CNPG secret. When `false` and `global.cnpg.enabled=true`, CNPG is deployed in parallel (migration mode) while Penpot keeps using Bitnami PostgreSQL. |
 | config.existingSecret | string | `""` | The name of an existing secret. |
 | config.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to all the containers (frontend, backend and exporter) in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | config.fileDataBackend | string | `"legacy-db"` | Define the strategy (backend) for internal file data storage of Penpot. Use "legacy-db" (default) the current behaviour, "db" to use an specific table in the database (future default) and "storage" to use the predefined objects storage system (S3, file system,...) |
@@ -152,6 +152,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | config.postgresql.secretKeys.passwordKey | string | `""` | The password key to use from an existing secret. |
 | config.postgresql.secretKeys.postgresqlUriKey | string | `""` | The postgresql uri key to use from an existing secret. (postgresql://host:port/database). |
 | config.postgresql.secretKeys.usernameKey | string | `""` | The username key to use from an existing secret. |
+| config.postgresql.useAsPrimary | bool | `false` |  |
 | config.postgresql.username | string | `"penpot"` | The database username to use. |
 | config.privacyPolicyUri | string | `""` | Url adress to Privacy Policy (empty to hide the link) |
 | config.providers.existingSecret | string | `""` | The name of an existing secret to use. |

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -13,6 +13,24 @@ Penpot is available on browser and [self host](https://penpot.app/self-host). It
 
 ## Installing the Chart
 
+### Prerequisite: CloudNativePG operator (required when using CNPG)
+
+To use CloudNativePG (CNPG) as PostgreSQL backend, your Kubernetes cluster must have the CloudNativePG operator installed (it provides the postgresql.cnpg.io CRDs). If it’s not installed, the chart will fail to create CNPG resources.
+
+Install CloudNativePG operator:
+
+```console
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+```
+The following command installs the CloudNativePG operator and its required Custom Resource Definitions (CRDs):
+
+```consola
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+  --namespace cnpg-system --create-namespace
+```
+### Install penpot 
+
 To install the chart with the release name `my-release`:
 
 ```console
@@ -24,7 +42,7 @@ You can customize the installation specify each parameter using the `--set key=v
 
 ```console
 helm install my-release \
-  --set global.postgresqlEnabled=true \
+  --set global.cnpg.enabled=true \
   --set global.valkeyEnabled=true \
   --set persistence.assets.enabled=true \
   penpot/{{ template "chart.name" . }}
@@ -235,6 +253,77 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 
 
 ## Upgrading
+
+### To 1.0.0
+
+Bitnami is changing the way its Helm charts are maintained and distributed, which impacts how PostgreSQL is deployed and managed in Kubernetes environments. As a result, Penpot is moving away from the Bitnami PostgreSQL chart and adopting **CloudNativePG (CNPG)** as its PostgreSQL operator.
+
+This allows Penpot to rely on a Kubernetes-native, actively maintained solution for PostgreSQL lifecycle management, backups, and replication.
+
+This change introduces new configuration flags and **requires a manual data migration** if you are upgrading an existing installation that previously used Bitnami PostgreSQL.
+
+Depending on your current setup, follow **one of the scenarios below**.
+
+#### Migrating from Bitnami PostgreSQL to CloudNativePG
+
+If your Penpot installation was previously using the Bitnami PostgreSQL Helm chart, the database data must be migrated to a new CloudNativePG cluster.
+
+⚠️ **MIGRATION IS A MANUAL AND SAFE PROCESS AND WILL NOT BE PERFORMED AUTOMATICALLY.**
+
+##### Step 1: Enable CloudNativePG (migration mode)
+
+First, deploy CloudNativePG **while keeping Bitnami PostgreSQL enabled**:
+
+```console
+helm upgrade --install penpot . -n penpot \
+  --set global.cnpg.enabled=true \
+  --set global.postgresqlEnabled=true \
+  --set global.valkeyEnabled=true
+```
+
+##### Step 2: Run the migration script
+
+Once CloudNativePG is available, run the migration script:
+```console
+./scripts/upgrade/1.0.0/migrate-bitnami-to-cnpg.sh
+```
+
+This script will:
+
+* Connect to the existing Bitnami PostgreSQL instance
+
+* Dump the current database
+
+* Restore the data into the CloudNativePG cluster
+
+* Output the final Helm command required to complete the migration
+
+##### Step 3: Switch CloudNativePG as primary database
+
+After the migration finishes successfully, execute the command provided by the script, for example:
+```console
+helm upgrade --install penpot . -n penpot \
+  --set global.cnpg.enabled=true \
+  --set global.cnpg.useAsPrimary=true \
+  --set global.postgresqlEnabled=false \
+  --set global.valkeyEnabled=true
+```
+
+Once this step is completed:
+
+* CloudNativePG becomes the primary PostgreSQL backend
+
+* Bitnami PostgreSQL is disabled
+
+* Penpot runs fully on CloudNativePG
+
+##### Important notes
+
+* Migration is never automatic
+
+* Penpot will not switch databases unless global.cnpg.useAsPrimary=true
+
+* Bitnami PostgreSQL is supported only for **the next 3 chart releases**
 
 ### To 0.29.0
 

--- a/charts/penpot/templates/NOTES.txt
+++ b/charts/penpot/templates/NOTES.txt
@@ -25,18 +25,60 @@
 
 {{- $global := .Values.global | default dict -}}
 {{- $cnpg := $global.cnpg | default dict -}}
-{{- $cnpgEnabled := default false $cnpg.enabled -}}
-{{- $cnpgUseAsPrimary := default false $cnpg.useAsPrimary -}}
-{{- $postgresqlEnabled := default true $global.postgresqlEnabled -}}
+
+{{- /* Coerce values to real booleans (avoid "false" string being truthy) */ -}}
+{{- $cnpgEnabled := eq (include "penpot.bool" (default false $cnpg.enabled)) "true" -}}
+{{- $cnpgUseAsPrimary := eq (include "penpot.bool" (default false $cnpg.useAsPrimary)) "true" -}}
+
+{{- /* Backward compatible: if global.postgresqlEnabled is not set, assume true */ -}}
+{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
+{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
 
 {{- $bitnamiSts := lookup "apps/v1" "StatefulSet" $ns (printf "%s-postgresql" $release) -}}
 {{- $cnpgCluster := lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release) -}}
+
+{{- /* invalid ONLY when user intent is contradictory */ -}}
+{{- $invalidConfig := and $postgresqlEnabled $cnpgUseAsPrimary -}}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* Invalid combination: Bitnami enabled + CNPG useAsPrimary=true          */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if $invalidConfig }}
+
+🚫 INVALID CONFIGURATION
+
+You have enabled BOTH:
+- Bitnami PostgreSQL: global.postgresqlEnabled=true
+- CNPG primary switch: global.cnpg.useAsPrimary=true
+
+This combination is NOT supported.
+
+Choose ONE of these valid setups:
+
+✅ MIGRATION MODE (recommended first step):
+  --set global.cnpg.enabled=true \
+  --set global.postgresqlEnabled=true
+  (keep global.cnpg.useAsPrimary=false)
+
+✅ FINAL CUTOVER (after running the migration script):
+  --set global.cnpg.enabled=true \
+  --set global.postgresqlEnabled=false \
+  --set global.cnpg.useAsPrimary=true
+
+{{- end }}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* Normal messages (only if config is valid)                              */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if not $invalidConfig }}
 
 {{- /* --------------------------------------------------------------------- */ -}}
 {{- /* Bitnami PostgreSQL ACTIVE (PRIMARY)                                    */ -}}
 {{- /* --------------------------------------------------------------------- */ -}}
 
-{{- if and $postgresqlEnabled (not $cnpgEnabled) }} 
+{{- if and $postgresqlEnabled (not $cnpgEnabled) }}
 
 ⚠️  POSTGRESQL (BITNAMI) DEPRECATION NOTICE
 
@@ -49,7 +91,7 @@ MIGRATION IS A MANUAL AND SAFE PROCESS AND WILL NOT BE PERFORMED AUTOMATICALLY.
 
 RECOMMENDED NEXT STEP (PREPARE MIGRATION):
 
-  helm upgrade --install {{ $release }} . -n {{ $ns }} --create-namespace \
+  helm upgrade --install {{ $release }} <chart> -n {{ $ns }} --create-namespace \
     --set global.cnpg.enabled=true \
     --set global.postgresqlEnabled=true
 
@@ -74,9 +116,11 @@ Both PostgreSQL backends are enabled:
 No data migration is performed automatically.
 
 Next steps:
-1) Run the Bitnami → CNPG migration process
+1) Run the Bitnami → CNPG migration script
 2) Switch CNPG as primary (FINAL CUTOVER):
-   --set global.postgresqlEnabled=false --set global.cnpg.useAsPrimary=true
+
+   --set global.postgresqlEnabled=false \
+   --set global.cnpg.useAsPrimary=true
 
 Migration guide:
   https://github.com/penpot/penpot-helm/blob/main/docs/migration/bitnami-to-cnpg.md
@@ -95,12 +139,13 @@ CloudNativePG (CNPG) is configured as the PRIMARY PostgreSQL backend
 for this Penpot installation.
 
 Penpot will use:
-  {{ printf "%s-cnpg-postgresql-rw" $release }}
+
+  {{ include "penpot.postgresqlHost" . }}
 
 {{- end }}
 
 {{- /* --------------------------------------------------------------------- */ -}}
-{{- /* CNPG-only install confirmation (no Bitnami resources)                 */ -}}
+{{- /* CNPG-only install confirmation (no Bitnami resources)                  */ -}}
 {{- /* --------------------------------------------------------------------- */ -}}
 
 {{- if and $cnpgEnabled (not $postgresqlEnabled) (not $bitnamiSts) }}
@@ -113,7 +158,7 @@ No Bitnami PostgreSQL components are present.
 {{- end }}
 
 {{- /* --------------------------------------------------------------------- */ -}}
-{{- /* Legacy migration detection (resource-based, optional)                */ -}}
+{{- /* Legacy migration detection (resource-based, optional)                  */ -}}
 {{- /* --------------------------------------------------------------------- */ -}}
 
 {{- if and $bitnamiSts $cnpgCluster $postgresqlEnabled (not $cnpgUseAsPrimary) }}
@@ -126,5 +171,7 @@ Two PostgreSQL backends are present in the cluster:
 - CloudNativePG: {{ $cnpgCluster.metadata.name }}
 
 This is consistent with a migration-in-progress setup.
+
+{{- end }}
 
 {{- end }}

--- a/charts/penpot/templates/NOTES.txt
+++ b/charts/penpot/templates/NOTES.txt
@@ -3,16 +3,128 @@
   APP VERSION: {{ .Chart.AppVersion }}
   CHART VERSION: {{ .Chart.Version }}
   RELEASE NAME: {{ .Release.Name }}
-  
   To learn more about the release, try:
-  
     $ helm status {{ .Release.Name }}
     $ helm get all {{ .Release.Name }}
-  
-  {{- if .Values.global.redisEnabled }}
 
-  DEPRECATION WARNING: 
-     Since Penpot 2.8, Penpot has migrated from Redis to Valkey. 
+{{- if .Values.global.redisEnabled }}
+
+  DEPRECATION WARNING:
+     Since Penpot 2.8, Penpot has migrated from Redis to Valkey.
      Although migration is recommended, Penpot will work seamlessly
      with compatible Redis versions.
-  {{- end }}
+
+{{- end }}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* PostgreSQL detection                                                   */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- $ns := .Release.Namespace -}}
+{{- $release := .Release.Name -}}
+
+{{- $global := .Values.global | default dict -}}
+{{- $cnpg := $global.cnpg | default dict -}}
+{{- $cnpgEnabled := default false $cnpg.enabled -}}
+{{- $cnpgUseAsPrimary := default false $cnpg.useAsPrimary -}}
+{{- $postgresqlEnabled := default true $global.postgresqlEnabled -}}
+
+{{- $bitnamiSts := lookup "apps/v1" "StatefulSet" $ns (printf "%s-postgresql" $release) -}}
+{{- $cnpgCluster := lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release) -}}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* Bitnami PostgreSQL ACTIVE (PRIMARY)                                    */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if and $postgresqlEnabled (not $cnpgEnabled) }} 
+
+⚠️  POSTGRESQL (BITNAMI) DEPRECATION NOTICE
+
+BITNAMI POSTGRESQL WILL BE SUPPORTED FOR THE NEXT 3 CHART RELEASES ONLY.
+AFTER THAT, IT WILL BE OFFICIALLY DEPRECATED AND REMOVED AS A SUPPORTED OPTION.
+
+WE STRONGLY RECOMMEND PLANNING A MIGRATION TO CLOUDNATIVEPG (CNPG).
+
+MIGRATION IS A MANUAL AND SAFE PROCESS AND WILL NOT BE PERFORMED AUTOMATICALLY.
+
+RECOMMENDED NEXT STEP (PREPARE MIGRATION):
+
+  helm upgrade --install {{ $release }} . -n {{ $ns }} --create-namespace \
+    --set global.cnpg.enabled=true \
+    --set global.postgresqlEnabled=true
+
+MIGRATION GUIDE:
+  https://github.com/penpot/penpot-helm/blob/main/docs/migration/bitnami-to-cnpg.md
+
+{{- end }}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* Migration mode (Bitnami + CNPG enabled)                                */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if and $cnpgEnabled $postgresqlEnabled }}
+
+🟡 POSTGRESQL MIGRATION MODE (BITNAMI → CNPG)
+
+Both PostgreSQL backends are enabled:
+
+- ACTIVE (CURRENT): Bitnami PostgreSQL
+- DEPLOYED (FOR MIGRATION): CloudNativePG (CNPG)
+
+No data migration is performed automatically.
+
+Next steps:
+1) Run the Bitnami → CNPG migration process
+2) Switch CNPG as primary (FINAL CUTOVER):
+   --set global.postgresqlEnabled=false --set global.cnpg.useAsPrimary=true
+
+Migration guide:
+  https://github.com/penpot/penpot-helm/blob/main/docs/migration/bitnami-to-cnpg.md
+
+{{- end }}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* CloudNativePG ACTIVE (PRIMARY)                                         */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) }}
+
+🟢 CLOUDNATIVEPG ACTIVE (PRIMARY)
+
+CloudNativePG (CNPG) is configured as the PRIMARY PostgreSQL backend
+for this Penpot installation.
+
+Penpot will use:
+  {{ printf "%s-cnpg-postgresql-rw" $release }}
+
+{{- end }}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* CNPG-only install confirmation (no Bitnami resources)                 */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if and $cnpgEnabled (not $postgresqlEnabled) (not $bitnamiSts) }}
+
+✅ CLOUDNATIVEPG-ONLY INSTALLATION CONFIRMED
+
+This Penpot installation is running with CloudNativePG ONLY.
+No Bitnami PostgreSQL components are present.
+
+{{- end }}
+
+{{- /* --------------------------------------------------------------------- */ -}}
+{{- /* Legacy migration detection (resource-based, optional)                */ -}}
+{{- /* --------------------------------------------------------------------- */ -}}
+
+{{- if and $bitnamiSts $cnpgCluster $postgresqlEnabled (not $cnpgUseAsPrimary) }}
+
+ℹ️  POSTGRESQL MIGRATION RESOURCES DETECTED
+
+Two PostgreSQL backends are present in the cluster:
+
+- Bitnami PostgreSQL: {{ $bitnamiSts.metadata.name }}
+- CloudNativePG: {{ $cnpgCluster.metadata.name }}
+
+This is consistent with a migration-in-progress setup.
+
+{{- end }}

--- a/charts/penpot/templates/NOTES.txt
+++ b/charts/penpot/templates/NOTES.txt
@@ -16,33 +16,14 @@
 
 {{- end }}
 
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* PostgreSQL detection                                                   */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
 {{- $ns := .Release.Namespace -}}
 {{- $release := .Release.Name -}}
 
-{{- $global := .Values.global | default dict -}}
-{{- $cnpg := $global.cnpg | default dict -}}
+{{- $cnpgEnabled := eq (include "penpot.cnpgEnabled" .) "true" -}}
+{{- $cnpgUseAsPrimary := eq (include "penpot.cnpgUseAsPrimary" .) "true" -}}
+{{- $postgresqlEnabled := eq (include "penpot.postgresqlEnabled" .) "true" -}}
 
-{{- /* Coerce values to real booleans (avoid "false" string being truthy) */ -}}
-{{- $cnpgEnabled := eq (include "penpot.bool" (default false $cnpg.enabled)) "true" -}}
-{{- $cnpgUseAsPrimary := eq (include "penpot.bool" (default false $cnpg.useAsPrimary)) "true" -}}
-
-{{- /* Backward compatible: if global.postgresqlEnabled is not set, assume true */ -}}
-{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
-{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
-
-{{- $bitnamiSts := lookup "apps/v1" "StatefulSet" $ns (printf "%s-postgresql" $release) -}}
-{{- $cnpgCluster := lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release) -}}
-
-{{- /* invalid ONLY when user intent is contradictory */ -}}
 {{- $invalidConfig := and $postgresqlEnabled $cnpgUseAsPrimary -}}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* Invalid combination: Bitnami enabled + CNPG useAsPrimary=true          */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
 
 {{- if $invalidConfig }}
 
@@ -50,35 +31,23 @@
 
 You have enabled BOTH:
 - Bitnami PostgreSQL: global.postgresqlEnabled=true
-- CNPG primary switch: global.cnpg.useAsPrimary=true
+- CNPG primary switch: global.cnpgUseAsPrimary=true
 
 This combination is NOT supported.
 
 Choose ONE of these valid setups:
 
 ✅ MIGRATION MODE (recommended first step):
-  --set global.cnpg.enabled=true \
+  --set global.cnpgEnabled=true \
   --set global.postgresqlEnabled=true
-  (keep global.cnpg.useAsPrimary=false)
+  (keep global.cnpgUseAsPrimary=false)
 
 ✅ FINAL CUTOVER (after running the migration script):
-  --set global.cnpg.enabled=true \
+  --set global.cnpgEnabled=true \
   --set global.postgresqlEnabled=false \
-  --set global.cnpg.useAsPrimary=true
+  --set global.cnpgUseAsPrimary=true
 
-{{- end }}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* Normal messages (only if config is valid)                              */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
-{{- if not $invalidConfig }}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* Bitnami PostgreSQL ACTIVE (PRIMARY)                                    */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
-{{- if and $postgresqlEnabled (not $cnpgEnabled) }}
+{{- else if and $postgresqlEnabled (not $cnpgEnabled) }}
 
 ⚠️  POSTGRESQL (BITNAMI) DEPRECATION NOTICE
 
@@ -92,19 +61,13 @@ MIGRATION IS A MANUAL AND SAFE PROCESS AND WILL NOT BE PERFORMED AUTOMATICALLY.
 RECOMMENDED NEXT STEP (PREPARE MIGRATION):
 
   helm upgrade --install {{ $release }} <chart> -n {{ $ns }} --create-namespace \
-    --set global.cnpg.enabled=true \
+    --set global.cnpgEnabled=true \
     --set global.postgresqlEnabled=true
 
 MIGRATION GUIDE:
   https://github.com/penpot/penpot-helm/blob/main/docs/migration/bitnami-to-cnpg.md
 
-{{- end }}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* Migration mode (Bitnami + CNPG enabled)                                */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
-{{- if and $cnpgEnabled $postgresqlEnabled }}
+{{- else if and $cnpgEnabled $postgresqlEnabled (not $cnpgUseAsPrimary) }}
 
 🟡 POSTGRESQL MIGRATION MODE (BITNAMI → CNPG)
 
@@ -120,18 +83,12 @@ Next steps:
 2) Switch CNPG as primary (FINAL CUTOVER):
 
    --set global.postgresqlEnabled=false \
-   --set global.cnpg.useAsPrimary=true
+   --set global.cnpgUseAsPrimary=true
 
 Migration guide:
   https://github.com/penpot/penpot-helm/blob/main/docs/migration/bitnami-to-cnpg.md
 
-{{- end }}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* CloudNativePG ACTIVE (PRIMARY)                                         */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
-{{- if and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) }}
+{{- else if and $cnpgEnabled (not $postgresqlEnabled) }}
 
 🟢 CLOUDNATIVEPG ACTIVE (PRIMARY)
 
@@ -140,38 +97,6 @@ for this Penpot installation.
 
 Penpot will use:
 
-  {{ include "penpot.postgresqlHost" . }}
-
-{{- end }}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* CNPG-only install confirmation (no Bitnami resources)                  */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
-{{- if and $cnpgEnabled (not $postgresqlEnabled) (not $bitnamiSts) }}
-
-✅ CLOUDNATIVEPG-ONLY INSTALLATION CONFIRMED
-
-This Penpot installation is running with CloudNativePG ONLY.
-No Bitnami PostgreSQL components are present.
-
-{{- end }}
-
-{{- /* --------------------------------------------------------------------- */ -}}
-{{- /* Legacy migration detection (resource-based, optional)                  */ -}}
-{{- /* --------------------------------------------------------------------- */ -}}
-
-{{- if and $bitnamiSts $cnpgCluster $postgresqlEnabled (not $cnpgUseAsPrimary) }}
-
-ℹ️  POSTGRESQL MIGRATION RESOURCES DETECTED
-
-Two PostgreSQL backends are present in the cluster:
-
-- Bitnami PostgreSQL: {{ $bitnamiSts.metadata.name }}
-- CloudNativePG: {{ $cnpgCluster.metadata.name }}
-
-This is consistent with a migration-in-progress setup.
-
-{{- end }}
+  {{ printf "%s-cnpg-postgresql-rw" $release }}
 
 {{- end }}

--- a/charts/penpot/templates/_helpers.tpl
+++ b/charts/penpot/templates/_helpers.tpl
@@ -7,6 +7,8 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "penpot.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -47,18 +49,21 @@ Selector labels
 app.kubernetes.io/name: {{ include "penpot.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
 {{- define "penpot.frontendSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "penpot.name" . }}-frontend
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+{{- end -}}
+
 {{- define "penpot.backendSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "penpot.name" . }}-backend
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+{{- end -}}
+
 {{- define "penpot.exporterSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "penpot.name" . }}-exporter
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
+{{- end -}}
 
 {{/*
 Create the name of the service account to use
@@ -71,40 +76,116 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/* --------------------------------------------------------------------- */}}
+{{/* ------------------------ CNPG / PostgreSQL helpers ------------------- */}}
+{{/* --------------------------------------------------------------------- */}}
+
+{{/*
+Coerce a value to boolean string: "true" or "false"
+Accepts: true/false, "true"/"false", "1"/"0", 1/0
+*/}}
+{{- define "penpot.bool" -}}
+{{- $v := printf "%v" . -}}
+{{- if or (eq $v "true") (eq $v "1") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+Return "true" if global.postgresqlEnabled was explicitly set by the user (in values or via --set).
+*/}}
+{{- define "penpot.pgEnabledIsSet" -}}
+{{- $g := .Values.global | default dict -}}
+{{- if hasKey $g "postgresqlEnabled" -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+Return pgEnabled as boolean string ("true"/"false").
+Default is "true" ONLY when not explicitly set (backward compatible).
+*/}}
+{{- define "penpot.pgEnabled" -}}
+{{- $g := .Values.global | default dict -}}
+{{- if hasKey $g "postgresqlEnabled" -}}
+{{- include "penpot.bool" $g.postgresqlEnabled -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Detect whether Bitnami PostgreSQL exists in the cluster (installed already).
+*/}}
+{{- define "penpot.bitnamiPresent" -}}
+{{- $ns := .Release.Namespace -}}
+{{- $name := printf "%s-postgresql" .Release.Name -}}
+{{- $sts := lookup "apps/v1" "StatefulSet" $ns $name -}}
+{{- if $sts -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+CNPG is primary if:
+- CNPG enabled AND
+- (
+    useAsPrimary=true (explicit switch), OR
+    (postgresqlEnabled is NOT explicitly set AND Bitnami is NOT present)  -> new install CNPG
+  )
+AND postgresqlEnabled is NOT explicitly true.
+
+This matches your scenarios:
+1) new install: cnpg.enabled=true, pg not set, bitnami not present -> CNPG primary
+2) bitnami only: postgresqlEnabled=true -> Bitnami primary
+3) migration mode: cnpg.enabled=true + postgresqlEnabled=true -> Bitnami primary
+4) switch: cnpg.enabled=true + cnpg.useAsPrimary=true + postgresqlEnabled=false -> CNPG primary
+*/}}
+{{- define "penpot.cnpgIsPrimary" -}}
+{{- $g := .Values.global | default dict -}}
+{{- $cnpg := $g.cnpg | default dict -}}
+
+{{- $cnpgEnabled := eq (include "penpot.bool" (default false $cnpg.enabled)) "true" -}}
+{{- $useAsPrimary := eq (include "penpot.bool" (default false $cnpg.useAsPrimary)) "true" -}}
+
+{{- $pgEnabled := eq (include "penpot.pgEnabled" .) "true" -}}
+{{- $pgIsSet := eq (include "penpot.pgEnabledIsSet" .) "true" -}}
+{{- $bitnamiPresent := eq (include "penpot.bitnamiPresent" .) "true" -}}
+
+{{- if and $cnpgEnabled (not $pgEnabled) -}}
+true
+{{- else if and $cnpgEnabled $useAsPrimary (not $pgEnabled) -}}
+true
+{{- else if and $cnpgEnabled (not $pgIsSet) (not $bitnamiPresent) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{/*
 Resolve the PostgreSQL host to use.
-
-Behavior:
-- Bitnami PostgreSQL is used when global.postgresqlEnabled=true
-- CNPG is ONLY used when:
-  - global.cnpg.enabled=true
-  - global.cnpg.useAsPrimary=true
-  - global.postgresqlEnabled=false
 */}}
 {{- define "penpot.postgresqlHost" -}}
-{{- $global := .Values.global | default dict -}}
-{{- $cnpg := $global.cnpg | default dict -}}
-
-{{- $cnpgEnabledRaw := default false $cnpg.enabled -}}
-{{- $cnpgUseAsPrimaryRaw := default false $cnpg.useAsPrimary -}}
-{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
-
-{{- $cnpgEnabled := eq (include "penpot.bool" $cnpgEnabledRaw) "true" -}}
-{{- $cnpgUseAsPrimary := eq (include "penpot.bool" $cnpgUseAsPrimaryRaw) "true" -}}
-{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
-
 {{- if .Values.config.postgresql.host -}}
 {{- .Values.config.postgresql.host -}}
-{{- else if and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) -}}
+{{- else if eq (include "penpot.cnpgIsPrimary" .) "true" -}}
 {{- printf "%s-cnpg-postgresql-rw" .Release.Name -}}
 {{- else -}}
 {{- printf "%s-postgresql" .Release.Name -}}
 {{- end -}}
-{{- end }}
+{{- end -}}
+
+{{/*
+Return the secret name used for DB credentials.
+*/}}
+{{- define "penpot.postgresqlSecretName" -}}
+{{- if .Values.config.postgresql.existingSecret -}}
+{{- .Values.config.postgresql.existingSecret -}}
+{{- else if eq (include "penpot.cnpgIsPrimary" .) "true" -}}
+{{- printf "%s-cnpg-db-secret" .Release.Name -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Return CNPG app password:
-- If secret exists, reuse it
+- If secret exists, reuse it (avoid regen on upgrade)
 - Else use config.postgresql.password if set
 - Else generate one
 */}}
@@ -119,43 +200,16 @@ Return CNPG app password:
 {{- else -}}
 {{- randAlphaNum 32 -}}
 {{- end -}}
-{{- end }}
-
-{{/*
-Return the secret name used for DB credentials
-*/}}
-{{- define "penpot.postgresqlSecretName" -}}
-{{- $global := .Values.global | default dict -}}
-{{- $cnpg := $global.cnpg | default dict -}}
-
-{{- $cnpgEnabledRaw := default false $cnpg.enabled -}}
-{{- $cnpgUseAsPrimaryRaw := default false $cnpg.useAsPrimary -}}
-{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
-
-{{- $cnpgEnabled := eq (include "penpot.bool" $cnpgEnabledRaw) "true" -}}
-{{- $cnpgUseAsPrimary := eq (include "penpot.bool" $cnpgUseAsPrimaryRaw) "true" -}}
-{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
-
-{{- $cnpgPrimary := and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) -}}
-
-{{- if .Values.config.postgresql.existingSecret -}}
-{{- .Values.config.postgresql.existingSecret -}}
-{{- else if $cnpgPrimary -}}
-{{- printf "%s-cnpg-db-secret" .Release.Name -}}
-{{- else -}}
-{{- "" -}}
 {{- end -}}
-{{- end }}
-
 {{/*
-Coerce a value to boolean.
-Accepts: true/false, "true"/"false", "1"/"0", 1/0
+Return true if configuration is invalid:
+- Bitnami PostgreSQL enabled AND
+- CNPG useAsPrimary enabled
 */}}
-{{- define "penpot.bool" -}}
-{{- $v := printf "%v" . -}}
-{{- if or (eq $v "true") (eq $v "1") -}}
-true
-{{- else -}}
-false
-{{- end -}}
+{{- define "penpot.invalidConfig" -}}
+{{- $pgEnabled := eq (include "penpot.pgEnabled" .) "true" -}}
+{{- $g := .Values.global | default dict -}}
+{{- $cnpg := $g.cnpg | default dict -}}
+{{- $useAsPrimary := eq (include "penpot.bool" (default false $cnpg.useAsPrimary)) "true" -}}
+{{- if and $pgEnabled $useAsPrimary -}}true{{- else -}}false{{- end -}}
 {{- end -}}

--- a/charts/penpot/templates/_helpers.tpl
+++ b/charts/penpot/templates/_helpers.tpl
@@ -1,38 +1,29 @@
 {{/*
-Expand the name of the chart.
+Common helpers (name/fullname/labels)
 */}}
+
 {{- define "penpot.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "penpot.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "penpot.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
 
-{{/*
-Common labels
-*/}}
+{{- define "penpot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "penpot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
 {{- define "penpot.labels" -}}
 helm.sh/chart: {{ include "penpot.chart" . }}
 {{ include "penpot.selectorLabels" . }}
@@ -40,69 +31,51 @@ helm.sh/chart: {{ include "penpot.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "penpot.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "penpot.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
-
-{{- define "penpot.frontendSelectorLabels" -}}
-app.kubernetes.io/name: {{ include "penpot.name" . }}-frontend
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "penpot.backendSelectorLabels" -}}
-app.kubernetes.io/name: {{ include "penpot.name" . }}-backend
+app.kubernetes.io/name: {{ include "penpot.fullname" . }}-backend
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "penpot.frontendSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "penpot.fullname" . }}-frontend
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "penpot.exporterSelectorLabels" -}}
-app.kubernetes.io/name: {{ include "penpot.name" . }}-exporter
+app.kubernetes.io/name: {{ include "penpot.fullname" . }}-exporter
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+ServiceAccount name
 */}}
 {{- define "penpot.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "penpot.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+{{- if .Values.serviceAccount.enabled -}}
+{{- default (include "penpot.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
 
-{{/* --------------------------------------------------------------------- */}}
-{{/* ------------------------ CNPG / PostgreSQL helpers ------------------- */}}
-{{/* --------------------------------------------------------------------- */}}
 
 {{/*
-Coerce a value to boolean string: "true" or "false"
-Accepts: true/false, "true"/"false", "1"/"0", 1/0
+Booleans helpers
 */}}
 {{- define "penpot.bool" -}}
 {{- $v := printf "%v" . -}}
 {{- if or (eq $v "true") (eq $v "1") -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
-{{/*
-Return "true" if global.postgresqlEnabled was explicitly set by the user (in values or via --set).
-*/}}
-{{- define "penpot.pgEnabledIsSet" -}}
-{{- $g := .Values.global | default dict -}}
-{{- if hasKey $g "postgresqlEnabled" -}}true{{- else -}}false{{- end -}}
-{{- end -}}
 
 {{/*
-Return pgEnabled as boolean string ("true"/"false").
-Default is "true" ONLY when not explicitly set (backward compatible).
+Global flags (new flat flags)
 */}}
-{{- define "penpot.pgEnabled" -}}
+
+{{- define "penpot.postgresqlEnabled" -}}
 {{- $g := .Values.global | default dict -}}
+{{- /* Backward compat: if key is missing, default true */ -}}
 {{- if hasKey $g "postgresqlEnabled" -}}
 {{- include "penpot.bool" $g.postgresqlEnabled -}}
 {{- else -}}
@@ -110,55 +83,42 @@ true
 {{- end -}}
 {{- end -}}
 
-{{/*
-Detect whether Bitnami PostgreSQL exists in the cluster (installed already).
-*/}}
-{{- define "penpot.bitnamiPresent" -}}
-{{- $ns := .Release.Namespace -}}
-{{- $name := printf "%s-postgresql" .Release.Name -}}
-{{- $sts := lookup "apps/v1" "StatefulSet" $ns $name -}}
-{{- if $sts -}}true{{- else -}}false{{- end -}}
+{{- define "penpot.cnpgEnabled" -}}
+{{- $g := .Values.global | default dict -}}
+{{- include "penpot.bool" (default false $g.cnpgEnabled) -}}
 {{- end -}}
 
-{{/*
-CNPG is primary if:
-- CNPG enabled AND
-- (
-    useAsPrimary=true (explicit switch), OR
-    (postgresqlEnabled is NOT explicitly set AND Bitnami is NOT present)  -> new install CNPG
-  )
-AND postgresqlEnabled is NOT explicitly true.
+{{- define "penpot.cnpgUseAsPrimary" -}}
+{{- $g := .Values.global | default dict -}}
+{{- include "penpot.bool" (default false $g.cnpgUseAsPrimary) -}}
+{{- end -}}
 
-This matches your scenarios:
-1) new install: cnpg.enabled=true, pg not set, bitnami not present -> CNPG primary
-2) bitnami only: postgresqlEnabled=true -> Bitnami primary
-3) migration mode: cnpg.enabled=true + postgresqlEnabled=true -> Bitnami primary
-4) switch: cnpg.enabled=true + cnpg.useAsPrimary=true + postgresqlEnabled=false -> CNPG primary
+{{- define "penpot.cnpgSupported" -}}
+{{- .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
+{{- end -}}
+
+
+{{/*
+CNPG selection logic
+CNPG is primary when:
+- cnpgEnabled=true AND (postgresqlEnabled=false OR cnpgUseAsPrimary=true)
+
+This matches your desired behavior:
+1) New CNPG install (postgresqlEnabled=false) -> CNPG host
+2) Bitnami only (postgresqlEnabled=true, cnpgEnabled=false) -> Bitnami host
+3) Migration mode (both enabled) -> Bitnami host
+4) Final cutover (postgresqlEnabled=false + cnpgUseAsPrimary=true) -> CNPG host
 */}}
 {{- define "penpot.cnpgIsPrimary" -}}
-{{- $g := .Values.global | default dict -}}
-{{- $cnpg := $g.cnpg | default dict -}}
-
-{{- $cnpgEnabled := eq (include "penpot.bool" (default false $cnpg.enabled)) "true" -}}
-{{- $useAsPrimary := eq (include "penpot.bool" (default false $cnpg.useAsPrimary)) "true" -}}
-
-{{- $pgEnabled := eq (include "penpot.pgEnabled" .) "true" -}}
-{{- $pgIsSet := eq (include "penpot.pgEnabledIsSet" .) "true" -}}
-{{- $bitnamiPresent := eq (include "penpot.bitnamiPresent" .) "true" -}}
-
-{{- if and $cnpgEnabled (not $pgEnabled) -}}
-true
-{{- else if and $cnpgEnabled $useAsPrimary (not $pgEnabled) -}}
-true
-{{- else if and $cnpgEnabled (not $pgIsSet) (not $bitnamiPresent) -}}
-true
-{{- else -}}
-false
+{{- $cnpgEnabled := eq (include "penpot.cnpgEnabled" .) "true" -}}
+{{- $useAsPrimary := eq (include "penpot.cnpgUseAsPrimary" .) "true" -}}
+{{- $pgEnabled := eq (include "penpot.postgresqlEnabled" .) "true" -}}
+{{- if and $cnpgEnabled (or $useAsPrimary (not $pgEnabled)) -}}true{{- else -}}false{{- end -}}
 {{- end -}}
-{{- end -}}
+
 
 {{/*
-Resolve the PostgreSQL host to use.
+PostgreSQL host resolver
 */}}
 {{- define "penpot.postgresqlHost" -}}
 {{- if .Values.config.postgresql.host -}}
@@ -170,29 +130,12 @@ Resolve the PostgreSQL host to use.
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the secret name used for DB credentials.
-*/}}
-{{- define "penpot.postgresqlSecretName" -}}
-{{- if .Values.config.postgresql.existingSecret -}}
-{{- .Values.config.postgresql.existingSecret -}}
-{{- else if eq (include "penpot.cnpgIsPrimary" .) "true" -}}
-{{- printf "%s-cnpg-db-secret" .Release.Name -}}
-{{- else -}}
-{{- "" -}}
-{{- end -}}
-{{- end -}}
 
 {{/*
-Return CNPG app password:
-- If secret exists, reuse it (avoid regen on upgrade)
-- Else use config.postgresql.password if set
-- Else generate one
+CNPG password helper (reuse existing secret if exists, else use provided password, else generate)
 */}}
 {{- define "penpot.cnpgAppPassword" -}}
-{{- $ns := .Release.Namespace -}}
-{{- $name := printf "%s-cnpg-db-secret" .Release.Name -}}
-{{- $existing := lookup "v1" "Secret" $ns $name -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-cnpg-db-secret" .Release.Name) -}}
 {{- if $existing -}}
 {{- index $existing.data "password" | b64dec -}}
 {{- else if .Values.config.postgresql.password -}}
@@ -200,16 +143,4 @@ Return CNPG app password:
 {{- else -}}
 {{- randAlphaNum 32 -}}
 {{- end -}}
-{{- end -}}
-{{/*
-Return true if configuration is invalid:
-- Bitnami PostgreSQL enabled AND
-- CNPG useAsPrimary enabled
-*/}}
-{{- define "penpot.invalidConfig" -}}
-{{- $pgEnabled := eq (include "penpot.pgEnabled" .) "true" -}}
-{{- $g := .Values.global | default dict -}}
-{{- $cnpg := $g.cnpg | default dict -}}
-{{- $useAsPrimary := eq (include "penpot.bool" (default false $cnpg.useAsPrimary)) "true" -}}
-{{- if and $pgEnabled $useAsPrimary -}}true{{- else -}}false{{- end -}}
 {{- end -}}

--- a/charts/penpot/templates/_helpers.tpl
+++ b/charts/penpot/templates/_helpers.tpl
@@ -7,8 +7,6 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "penpot.fullname" -}}
 {{- if .Values.fullnameOverride }}
@@ -52,15 +50,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "penpot.frontendSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "penpot.name" . }}-frontend
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
+{{- end }}
 {{- define "penpot.backendSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "penpot.name" . }}-backend
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
+{{- end }}
 {{- define "penpot.exporterSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "penpot.name" . }}-exporter
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
+{{- end }}
 
 {{/*
 Create the name of the service account to use
@@ -73,3 +71,91 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Resolve the PostgreSQL host to use.
+
+Behavior:
+- Bitnami PostgreSQL is used when global.postgresqlEnabled=true
+- CNPG is ONLY used when:
+  - global.cnpg.enabled=true
+  - global.cnpg.useAsPrimary=true
+  - global.postgresqlEnabled=false
+*/}}
+{{- define "penpot.postgresqlHost" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $cnpg := $global.cnpg | default dict -}}
+
+{{- $cnpgEnabledRaw := default false $cnpg.enabled -}}
+{{- $cnpgUseAsPrimaryRaw := default false $cnpg.useAsPrimary -}}
+{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
+
+{{- $cnpgEnabled := eq (include "penpot.bool" $cnpgEnabledRaw) "true" -}}
+{{- $cnpgUseAsPrimary := eq (include "penpot.bool" $cnpgUseAsPrimaryRaw) "true" -}}
+{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
+
+{{- if .Values.config.postgresql.host -}}
+{{- .Values.config.postgresql.host -}}
+{{- else if and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) -}}
+{{- printf "%s-cnpg-postgresql-rw" .Release.Name -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return CNPG app password:
+- If secret exists, reuse it
+- Else use config.postgresql.password if set
+- Else generate one
+*/}}
+{{- define "penpot.cnpgAppPassword" -}}
+{{- $ns := .Release.Namespace -}}
+{{- $name := printf "%s-cnpg-db-secret" .Release.Name -}}
+{{- $existing := lookup "v1" "Secret" $ns $name -}}
+{{- if $existing -}}
+{{- index $existing.data "password" | b64dec -}}
+{{- else if .Values.config.postgresql.password -}}
+{{- .Values.config.postgresql.password -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the secret name used for DB credentials
+*/}}
+{{- define "penpot.postgresqlSecretName" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $cnpg := $global.cnpg | default dict -}}
+
+{{- $cnpgEnabledRaw := default false $cnpg.enabled -}}
+{{- $cnpgUseAsPrimaryRaw := default false $cnpg.useAsPrimary -}}
+{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
+
+{{- $cnpgEnabled := eq (include "penpot.bool" $cnpgEnabledRaw) "true" -}}
+{{- $cnpgUseAsPrimary := eq (include "penpot.bool" $cnpgUseAsPrimaryRaw) "true" -}}
+{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
+
+{{- $cnpgPrimary := and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) -}}
+
+{{- if .Values.config.postgresql.existingSecret -}}
+{{- .Values.config.postgresql.existingSecret -}}
+{{- else if $cnpgPrimary -}}
+{{- printf "%s-cnpg-db-secret" .Release.Name -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Coerce a value to boolean.
+Accepts: true/false, "true"/"false", "1"/"0", 1/0
+*/}}
+{{- define "penpot.bool" -}}
+{{- $v := printf "%v" . -}}
+{{- if or (eq $v "true") (eq $v "1") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -1,5 +1,3 @@
-{{- $cnpgPrimary := eq (include "penpot.cnpgIsPrimary" .) "true" -}}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,7 +69,7 @@ spec:
             - name: PENPOT_TELEMETRY_REFERER
               value: kubernetes
             # PostgreSQL connection settings  
-           {{- $cnpgPrimary := eq (include "penpot.cnpgIsPrimary" .) "true" -}}
+              {{ $cnpgPrimary := eq (include "penpot.cnpgIsPrimary" .) "true" }}
             - name: PENPOT_DATABASE_URI
               {{- if $cnpgPrimary }}
               value: "postgresql://{{ include "penpot.postgresqlHost" . }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -1,16 +1,4 @@
-{{- $ns := .Release.Namespace -}}
-{{- $release := .Release.Name -}}
-{{- $cnpgSupported := .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
-{{- $global := .Values.global | default dict -}}
-{{- $cnpg := $global.cnpg | default dict -}}
-{{- $cnpgEnabledRaw := default false $cnpg.enabled -}}
-{{- $cnpgUseAsPrimaryRaw := default false $cnpg.useAsPrimary -}}
-{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
-{{- $cnpgEnabled := eq (include "penpot.bool" $cnpgEnabledRaw) "true" -}}
-{{- $cnpgUseAsPrimary := eq (include "penpot.bool" $cnpgUseAsPrimaryRaw) "true" -}}
-{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
-{{- $cnpgExisting := ternary (lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release)) nil $cnpgSupported -}}
-{{- $cnpgPrimary := and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) -}}
+{{- $cnpgPrimary := eq (include "penpot.cnpgIsPrimary" .) "true" -}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -84,9 +72,7 @@ spec:
               value: kubernetes
             # PostgreSQL connection settings
             - name: PENPOT_DATABASE_URI
-              {{- if $cnpgPrimary }}
-              value: "postgresql://{{ printf "%s-cnpg-postgresql-rw" .Release.Name }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
-              {{- else if .Values.config.postgresql.secretKeys.postgresqlUriKey }}
+              {{- if and .Values.config.postgresql.existingSecret .Values.config.postgresql.secretKeys.postgresqlUriKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
@@ -94,13 +80,14 @@ spec:
               {{- else }}
               value: "postgresql://{{ include "penpot.postgresqlHost" . }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
               {{- end }}
+
             - name: PENPOT_DATABASE_USERNAME
               {{- if $cnpgPrimary }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-cnpg-db-secret
                   key: username
-              {{- else if .Values.config.postgresql.secretKeys.usernameKey }}
+              {{- else if and .Values.config.postgresql.existingSecret .Values.config.postgresql.secretKeys.usernameKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
@@ -115,7 +102,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-cnpg-db-secret
                   key: password
-              {{- else if .Values.config.postgresql.secretKeys.passwordKey }}
+              {{- else if and .Values.config.postgresql.existingSecret .Values.config.postgresql.secretKeys.passwordKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
@@ -123,6 +110,7 @@ spec:
               {{- else }}
               value: {{ .Values.config.postgresql.password | quote }}
               {{- end }}
+
             # Valkey/Redis connection settings
             - name: PENPOT_REDIS_URI
               {{- if not .Values.config.redis.secretKeys.redisUriKey }}

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -70,9 +70,12 @@ spec:
               value: {{ .Values.config.telemetryEnabled | quote }}
             - name: PENPOT_TELEMETRY_REFERER
               value: kubernetes
-            # PostgreSQL connection settings
+            # PostgreSQL connection settings  
+           {{- $cnpgPrimary := eq (include "penpot.cnpgIsPrimary" .) "true" -}}
             - name: PENPOT_DATABASE_URI
-              {{- if and .Values.config.postgresql.existingSecret .Values.config.postgresql.secretKeys.postgresqlUriKey }}
+              {{- if $cnpgPrimary }}
+              value: "postgresql://{{ include "penpot.postgresqlHost" . }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
+              {{- else if .Values.config.postgresql.secretKeys.postgresqlUriKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
@@ -87,7 +90,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-cnpg-db-secret
                   key: username
-              {{- else if and .Values.config.postgresql.existingSecret .Values.config.postgresql.secretKeys.usernameKey }}
+              {{- else if .Values.config.postgresql.secretKeys.usernameKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
@@ -102,7 +105,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-cnpg-db-secret
                   key: password
-              {{- else if and .Values.config.postgresql.existingSecret .Values.config.postgresql.secretKeys.passwordKey }}
+              {{- else if .Values.config.postgresql.secretKeys.passwordKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
@@ -110,6 +113,7 @@ spec:
               {{- else }}
               value: {{ .Values.config.postgresql.password | quote }}
               {{- end }}
+
 
             # Valkey/Redis connection settings
             - name: PENPOT_REDIS_URI

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -1,3 +1,17 @@
+{{- $ns := .Release.Namespace -}}
+{{- $release := .Release.Name -}}
+{{- $cnpgSupported := .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $cnpg := $global.cnpg | default dict -}}
+{{- $cnpgEnabledRaw := default false $cnpg.enabled -}}
+{{- $cnpgUseAsPrimaryRaw := default false $cnpg.useAsPrimary -}}
+{{- $postgresqlEnabledRaw := ternary $global.postgresqlEnabled true (hasKey $global "postgresqlEnabled") -}}
+{{- $cnpgEnabled := eq (include "penpot.bool" $cnpgEnabledRaw) "true" -}}
+{{- $cnpgUseAsPrimary := eq (include "penpot.bool" $cnpgUseAsPrimaryRaw) "true" -}}
+{{- $postgresqlEnabled := eq (include "penpot.bool" $postgresqlEnabledRaw) "true" -}}
+{{- $cnpgExisting := ternary (lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release)) nil $cnpgSupported -}}
+{{- $cnpgPrimary := and $cnpgEnabled $cnpgUseAsPrimary (not $postgresqlEnabled) -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -68,37 +82,46 @@ spec:
               value: {{ .Values.config.telemetryEnabled | quote }}
             - name: PENPOT_TELEMETRY_REFERER
               value: kubernetes
-            # PosgreSQL connection settings
+            # PostgreSQL connection settings
             - name: PENPOT_DATABASE_URI
-              {{- if not .Values.config.postgresql.secretKeys.postgresqlUriKey }}
-                {{- if .Values.config.postgresql.host }}
-              value: "postgresql://{{ .Values.config.postgresql.host }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
-                {{- else }}
-              value: {{ print "postgresql://" (include "penpot.fullname" .) "-postgresql:" .Values.config.postgresql.port "/" .Values.config.postgresql.database }}
-                {{- end }}
-              {{- else }}
+              {{- if $cnpgPrimary }}
+              value: "postgresql://{{ printf "%s-cnpg-postgresql-rw" .Release.Name }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
+              {{- else if .Values.config.postgresql.secretKeys.postgresqlUriKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
                   key: {{ .Values.config.postgresql.secretKeys.postgresqlUriKey }}
+              {{- else }}
+              value: "postgresql://{{ include "penpot.postgresqlHost" . }}:{{ .Values.config.postgresql.port }}/{{ .Values.config.postgresql.database }}"
               {{- end }}
             - name: PENPOT_DATABASE_USERNAME
-              {{- if not .Values.config.postgresql.secretKeys.usernameKey }}
-              value: {{ .Values.config.postgresql.username | quote }}
-              {{- else }}
+              {{- if $cnpgPrimary }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-cnpg-db-secret
+                  key: username
+              {{- else if .Values.config.postgresql.secretKeys.usernameKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
                   key: {{ .Values.config.postgresql.secretKeys.usernameKey }}
-              {{- end }}
-            - name: PENPOT_DATABASE_PASSWORD
-              {{- if not .Values.config.postgresql.secretKeys.passwordKey }}
-              value: {{ .Values.config.postgresql.password | quote }}
               {{- else }}
+              value: {{ .Values.config.postgresql.username | quote }}
+              {{- end }}
+
+            - name: PENPOT_DATABASE_PASSWORD
+              {{- if $cnpgPrimary }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-cnpg-db-secret
+                  key: password
+              {{- else if .Values.config.postgresql.secretKeys.passwordKey }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.config.postgresql.existingSecret }}
                   key: {{ .Values.config.postgresql.secretKeys.passwordKey }}
+              {{- else }}
+              value: {{ .Values.config.postgresql.password | quote }}
               {{- end }}
             # Valkey/Redis connection settings
             - name: PENPOT_REDIS_URI

--- a/charts/penpot/templates/postgresql-cluster.yaml
+++ b/charts/penpot/templates/postgresql-cluster.yaml
@@ -1,0 +1,43 @@
+{{- $ns := .Release.Namespace -}}
+{{- $release := .Release.Name -}}
+{{- $cnpgSupported := .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $cnpg := $global.cnpg | default dict -}}
+{{- $cnpgEnabled := default false $cnpg.enabled -}}
+{{- $cnpgExisting := ternary (lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release)) nil $cnpgSupported -}}
+{{- if or $cnpgExisting $cnpgEnabled }}
+{{- $secretName := printf "%s-cnpg-db-secret" $release -}}
+{{- if and (or $cnpgExisting $cnpgEnabled) (not .Values.config.postgresql.existingSecret) }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $ns }}
+type: Opaque
+stringData:
+  username: {{ .Values.config.postgresql.username | quote }}
+  password: {{ include "penpot.cnpgAppPassword" . | quote }}
+---
+{{- end }}
+
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Release.Name }}-cnpg-postgresql
+  namespace: {{ $ns }}
+  annotations:
+    "helm.sh/resource-policy": keep
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  storage:
+    size: 8Gi
+  bootstrap:
+    initdb:
+      database: {{ .Values.config.postgresql.database | quote }}
+      owner: {{ .Values.config.postgresql.username | quote }}
+      secret:
+        name: {{ default $secretName .Values.config.postgresql.existingSecret | quote }}
+
+{{- end }}

--- a/charts/penpot/templates/postgresql-cluster.yaml
+++ b/charts/penpot/templates/postgresql-cluster.yaml
@@ -1,14 +1,15 @@
 {{- $ns := .Release.Namespace -}}
 {{- $release := .Release.Name -}}
-{{- $cnpgSupported := .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
-{{- $global := .Values.global | default dict -}}
-{{- $cnpg := $global.cnpg | default dict -}}
-{{- $cnpgEnabled := default false $cnpg.enabled -}}
-{{- $cnpgExisting := ternary (lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release)) nil $cnpgSupported -}}
-{{- if or $cnpgExisting $cnpgEnabled }}
-{{- $secretName := printf "%s-cnpg-db-secret" $release -}}
-{{- if and (or $cnpgExisting $cnpgEnabled) (not .Values.config.postgresql.existingSecret) }}
 
+{{- $cnpgSupported := eq (include "penpot.cnpgSupported" .) "true" -}}
+{{- $cnpgEnabled := eq (include "penpot.cnpgEnabled" .) "true" -}}
+
+{{- $cnpgExisting := ternary (lookup "postgresql.cnpg.io/v1" "Cluster" $ns (printf "%s-cnpg-postgresql" $release)) nil $cnpgSupported -}}
+
+{{- if and $cnpgSupported (or $cnpgExisting $cnpgEnabled) -}}
+{{- $secretName := printf "%s-cnpg-db-secret" $release -}}
+
+{{- if and (not $cnpgExisting) (not .Values.config.postgresql.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,7 +25,7 @@ stringData:
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ .Release.Name }}-cnpg-postgresql
+  name: {{ $release }}-cnpg-postgresql
   namespace: {{ $ns }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -40,4 +41,4 @@ spec:
       secret:
         name: {{ default $secretName .Values.config.postgresql.existingSecret | quote }}
 
-{{- end }}
+{{- end -}}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -99,7 +99,15 @@ config:
       # -- The password key to use from an existing secret.
       # @section -- Configuration parameters
       passwordKey: ""
-
+  cnpg:
+    # -- Enable CloudNativePG (CNPG) PostgreSQL cluster resources.::ex:Ex:E`:e`
+    # @section -- PostgreSQL
+    enabled: false
+    # -- Use CNPG as the primary database for Penpot.
+    # When `true`, the backend connects to CNPG and reads DB credentials from the internal CNPG secret.
+    # When `false` and `global.cnpg.enabled=true`, CNPG is deployed in parallel (migration mode) while Penpot keeps using Bitnami PostgreSQL.
+    # @section -- PostgreSQL
+    useAsPrimary: false
   redis:
     # -- The Valkey host to connect to. Empty to use dependencies
     # @section -- Configuration parameters
@@ -361,7 +369,7 @@ backend:
     repository: penpotapp/backend
     # -- The image tag to use.
     # @section -- Backend parameters
-    tag: 2.12.1
+    tag: 2.13.0
     # -- The image pull policy to use.
     # @section -- Backend parameters
     pullPolicy: IfNotPresent
@@ -456,7 +464,7 @@ frontend:
     repository: penpotapp/frontend
     # -- The image tag to use.
     # @section -- Frontend parameters
-    tag: 2.12.1
+    tag: 2.13.0
     # -- The image pull policy to use.
     # @section -- Frontend parameters
     pullPolicy: IfNotPresent
@@ -543,7 +551,7 @@ exporter:
     repository: penpotapp/exporter
     # -- The image tag to use.
     # @section -- Exporter parameters
-    tag: 2.12.1
+    tag: 2.13.0
     # -- The image pull policy to use.
     # @section -- Exporter parameters
     imagePullPolicy: IfNotPresent

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -18,7 +18,14 @@ global:
   #   - myRegistryKeySecretName
   # @section -- Global parameters
   imagePullSecrets: []
-
+  # -- Enable CloudNativePG (CNPG) resources (new installations or migration mode).
+  # @section -- PostgreSQL
+  cnpgEnabled: false
+  # -- Use CNPG as the primary database for Penpot.
+  # When `true`, the backend connects to CNPG and reads DB credentials from the internal CNPG secret.
+  # When `false` and `global.cnpgEnabled=true`, CNPG is deployed in parallel (migration mode) while Penpot keeps using Bitnami PostgreSQL.
+  # @section -- PostgreSQL
+  cnpgUseAsPrimary: false
 # -- To partially override common.names.fullname
 # @section -- Common parameters
 nameOverride: ""
@@ -99,14 +106,6 @@ config:
       # -- The password key to use from an existing secret.
       # @section -- Configuration parameters
       passwordKey: ""
-  cnpg:
-    # -- Enable CloudNativePG (CNPG) PostgreSQL cluster resources.::ex:Ex:E`:e`
-    # @section -- PostgreSQL
-    enabled: false
-    # -- Use CNPG as the primary database for Penpot.
-    # When `true`, the backend connects to CNPG and reads DB credentials from the internal CNPG secret.
-    # When `false` and `global.cnpg.enabled=true`, CNPG is deployed in parallel (migration mode) while Penpot keeps using Bitnami PostgreSQL.
-    # @section -- PostgreSQL
     useAsPrimary: false
   redis:
     # -- The Valkey host to connect to. Empty to use dependencies

--- a/scripts/upgrade/1.0.0/migrate-bitnami-to-cnpg.sh
+++ b/scripts/upgrade/1.0.0/migrate-bitnami-to-cnpg.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ------------------------------------------------------------------------------
+# migrate-bitnami-to-cnpg.sh
+#
+# Migrates Penpot PostgreSQL data from Bitnami subchart to CloudNativePG (CNPG)
+# in the same namespace.
+#
+# By default, it DOES NOT switch Penpot to CNPG automatically.
+# It prints the Helm command you should run after verifying the migration.
+#
+# Optional:
+#   --switch   -> also performs the switch (sets cnpg.useAsPrimary=true and disables Bitnami)
+# ------------------------------------------------------------------------------
+
+log() { printf '[%(%H:%M:%S)T] %s\n' -1 "$*"; }
+err() { printf '[%(%H:%M:%S)T] ERROR: %s\n' -1 "$*" >&2; }
+
+NS="${NS:-penpot}"
+RELEASE="${RELEASE:-penpot}"
+CHART_DIR="${CHART_DIR:-.}"
+
+# DB defaults (match your values.yaml defaults)
+DB_NAME="${DB_NAME:-penpot}"
+SRC_USER="${SRC_USER:-penpot}"
+TGT_USER="${TGT_USER:-penpot}"
+
+# Services (conventions used in your chart)
+SRC_HOST="${SRC_HOST:-${RELEASE}-postgresql}"              # Bitnami service name
+TGT_HOST="${TGT_HOST:-${RELEASE}-cnpg-postgresql-rw}"      # CNPG RW service name
+
+# Secrets
+CNPG_SECRET_NAME="${CNPG_SECRET_NAME:-${RELEASE}-cnpg-db-secret}"
+
+DO_SWITCH="false"
+if [[ "${1:-}" == "--switch" ]]; then
+  DO_SWITCH="true"
+fi
+
+cleanup_pod() {
+  local pod="$1"
+  kubectl -n "$NS" delete pod "$pod" --ignore-not-found >/dev/null 2>&1 || true
+}
+
+get_secret_key_b64() {
+  local secret="$1"
+  local key="$2"
+  kubectl -n "$NS" get secret "$secret" -o "jsonpath={.data.${key}}" 2>/dev/null || true
+}
+
+current_backend_db_uri() {
+  # Returns current PENPOT_DATABASE_URI from the backend (if deployment exists)
+  if kubectl -n "$NS" get deploy/penpot-backend >/dev/null 2>&1; then
+    kubectl -n "$NS" exec -it deploy/penpot-backend -- printenv 2>/dev/null | \
+      grep -E '^PENPOT_DATABASE_URI=' | head -n1 | cut -d= -f2- || true
+  else
+    echo ""
+  fi
+}
+
+read_password_from_helm_values() {
+  # Best-effort fallback: get password from computed values (values-driven installs)
+  # This is intentionally simple (no jq dependency).
+  # Tries (in order):
+  # - config.postgresql.password
+  # - postgresql.auth.password
+  local out
+  out="$(helm get values -n "$NS" "$RELEASE" -a 2>/dev/null || true)"
+  if [[ -z "$out" ]]; then
+    echo ""
+    return 0
+  fi
+
+  # Try config.postgresql.password
+  local p1
+  p1="$(printf '%s\n' "$out" | awk '
+    $1=="config:"{inconf=1}
+    inconf && $1=="postgresql:"{inpg=1; next}
+    inconf && inpg && $1=="password:"{print $2; exit}
+  ' | tr -d '"' )"
+  if [[ -n "${p1:-}" ]]; then
+    echo "$p1"
+    return 0
+  fi
+
+  # Try postgresql.auth.password (bitnami subchart)
+  local p2
+  p2="$(printf '%s\n' "$out" | awk '
+    $1=="postgresql:"{inpg=1}
+    inpg && $1=="auth:"{inauth=1; next}
+    inpg && inauth && $1=="password:"{print $2; exit}
+  ' | tr -d '"' )"
+  if [[ -n "${p2:-}" ]]; then
+    echo "$p2"
+    return 0
+  fi
+
+  echo ""
+}
+
+read_bitnami_password() {
+  # 1) If SRC_PASS is set in env, prefer it.
+  if [[ -n "${SRC_PASS:-}" ]]; then
+    echo "$SRC_PASS"
+    return 0
+  fi
+
+  # 2) Try Bitnami secret keys (varies by chart/config)
+  local secret="${RELEASE}-postgresql"
+
+  if kubectl -n "$NS" get secret "$secret" >/dev/null 2>&1; then
+    local b64=""
+    for k in password postgres-password postgresql-password "postgresql-postgres-password"; do
+      b64="$(get_secret_key_b64 "$secret" "$k")"
+      if [[ -n "$b64" ]]; then
+        echo "$b64" | base64 -d
+        return 0
+      fi
+    done
+  fi
+
+  # 3) Fallback: try to read from Helm computed values (values-driven)
+  local hv
+  hv="$(read_password_from_helm_values)"
+  if [[ -n "${hv:-}" ]]; then
+    echo "$hv"
+    return 0
+  fi
+
+  echo ""
+}
+
+read_cnpg_credentials() {
+  local user pass
+
+  if kubectl -n "$NS" get secret "$CNPG_SECRET_NAME" >/dev/null 2>&1; then
+    user="$(kubectl -n "$NS" get secret "$CNPG_SECRET_NAME" -o jsonpath='{.data.username}' 2>/dev/null | base64 -d || true)"
+    pass="$(kubectl -n "$NS" get secret "$CNPG_SECRET_NAME" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || true)"
+  else
+    user=""
+    pass=""
+  fi
+
+  # Fallback to defaults if secret doesn't have them (or secret missing)
+  if [[ -z "${user:-}" ]]; then user="$TGT_USER"; fi
+  if [[ -z "${pass:-}" ]]; then pass="${TGT_PASS:-penpot}"; fi
+
+  printf '%s\n%s\n' "$user" "$pass"
+}
+
+wait_for_endpoints() {
+  local svc="$1"
+  local tries=60
+  local i=0
+  while (( i < tries )); do
+    local eps
+    eps="$(kubectl -n "$NS" get endpoints "$svc" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
+    if [[ -n "$eps" ]]; then
+      return 0
+    fi
+    sleep 2
+    (( i++ ))
+  done
+  return 1
+}
+
+scale_penpot() {
+  local replicas="$1"
+  kubectl -n "$NS" scale deploy/penpot-backend deploy/penpot-frontend deploy/penpot-exporter --replicas="$replicas" >/dev/null
+}
+
+rollout_penpot() {
+  kubectl -n "$NS" rollout status deploy/penpot-backend --timeout=180s
+  kubectl -n "$NS" rollout status deploy/penpot-frontend --timeout=180s
+  kubectl -n "$NS" rollout status deploy/penpot-exporter --timeout=180s
+}
+
+main() {
+  log "Namespace: $NS"
+  log "Release:   $RELEASE"
+  log "Source DB: $SRC_HOST/$DB_NAME (Bitnami)"
+  log "Target DB: $TGT_HOST/$DB_NAME (CNPG)"
+
+  # Preflight: check current backend DB URI (avoid accidental migration when already pointing to CNPG empty)
+  local cur_uri
+  cur_uri="$(current_backend_db_uri || true)"
+  if [[ -n "${cur_uri:-}" ]]; then
+    log "Current backend PENPOT_DATABASE_URI: $cur_uri"
+    if echo "$cur_uri" | grep -q "${TGT_HOST}"; then
+      err "Backend is currently pointing to CNPG (${TGT_HOST})."
+      err "If CNPG is empty, Penpot will look 'broken' until data is migrated."
+      err "Recommended migration state BEFORE running this script:"
+      err "  - Bitnami enabled and used by Penpot (global.postgresqlEnabled=true)"
+      err "  - CNPG deployed but NOT primary (global.cnpg.enabled=true, cnpg.useAsPrimary=false)"
+      err "Then run this script."
+      # Not exiting hard, but strongly warning:
+    fi
+  else
+    log "Could not read current backend DB URI (deployment may not exist yet)."
+  fi
+
+  # Ensure CNPG RW service has endpoints (CNPG deployed & ready)
+  log "Waiting for CNPG RW service endpoints (${TGT_HOST})..."
+  if ! wait_for_endpoints "$TGT_HOST"; then
+    err "CNPG RW service '${TGT_HOST}' has no endpoints. Make sure CNPG is deployed and ready."
+    err "Example (migration prep, DO NOT switch yet):"
+    err "  helm upgrade --install ${RELEASE} ${CHART_DIR} -n ${NS} --create-namespace \\"
+    err "    --set global.postgresqlEnabled=true --set global.cnpg.enabled=true --set cnpg.useAsPrimary=false"
+    exit 1
+  fi
+
+  # Read passwords
+  log "Reading source password (Bitnami)..."
+  local SRC_PASS_LOCAL
+  SRC_PASS_LOCAL="$(read_bitnami_password)"
+  if [[ -z "$SRC_PASS_LOCAL" ]]; then
+    err "Could not determine Bitnami password."
+    err "Provide it explicitly and re-run:"
+    err "  SRC_PASS='...' $0"
+    exit 1
+  fi
+
+  log "Reading target credentials from CNPG secret (${CNPG_SECRET_NAME})..."
+  local creds TGT_PASS
+  creds="$(read_cnpg_credentials)"
+  TGT_USER="$(echo "$creds" | sed -n '1p')"
+  TGT_PASS="$(echo "$creds" | sed -n '2p')"
+
+  log "Scaling down Penpot deployments to 0 (avoid writes)..."
+  scale_penpot 0
+
+  local POD="pg-migrator-$(date +%Y%m%d-%H%M%S)"
+  trap 'log "Cleanup: ensuring Penpot deployments are running..."; scale_penpot 1 >/dev/null 2>&1 || true; cleanup_pod "'"$POD"'"' EXIT
+
+  log "Creating temporary migrator pod ${POD}..."
+  kubectl -n "$NS" run "$POD" \
+    --image=postgres:16-alpine \
+    --restart=Never \
+    --env="PGPASSWORD=${SRC_PASS_LOCAL}" \
+    --command -- sh -c "sleep 3600" >/dev/null
+
+  kubectl -n "$NS" wait --for=condition=Ready pod/"$POD" --timeout=120s >/dev/null
+
+  log "Running connectivity checks..."
+  kubectl -n "$NS" exec "$POD" -- sh -c "pg_isready -h '${SRC_HOST}' -p 5432 -U '${SRC_USER}'" >/dev/null
+  kubectl -n "$NS" exec "$POD" -- env "PGPASSWORD=${TGT_PASS}" sh -c "pg_isready -h '${TGT_HOST}' -p 5432 -U '${TGT_USER}'" >/dev/null
+
+  log "Preparing target schema (DROP/CREATE public)..."
+  kubectl -n "$NS" exec "$POD" -- env "PGPASSWORD=${TGT_PASS}" sh -c \
+    "psql -h '${TGT_HOST}' -U '${TGT_USER}' -d '${DB_NAME}' -v ON_ERROR_STOP=1 -c \"DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;\""
+
+  log "Dumping from Bitnami -> /tmp/penpot.dump ..."
+  kubectl -n "$NS" exec "$POD" -- sh -c \
+    "pg_dump -Fc -h '${SRC_HOST}' -U '${SRC_USER}' -d '${DB_NAME}' -f /tmp/penpot.dump"
+
+  log "Restoring into CNPG (full restore, schema recreated; no --clean needed)..."
+  kubectl -n "$NS" exec "$POD" -- env "PGPASSWORD=${TGT_PASS}" sh -c \
+    "pg_restore -h '${TGT_HOST}' -U '${TGT_USER}' -d '${DB_NAME}' --no-owner --no-privileges --exit-on-error /tmp/penpot.dump"
+
+  log "Quick verification (profiles count + sample email)..."
+  kubectl -n "$NS" exec "$POD" -- env "PGPASSWORD=${TGT_PASS}" sh -c \
+    "psql -h '${TGT_HOST}' -U '${TGT_USER}' -d '${DB_NAME}' -c \"select count(*) as profiles from profile;\""
+  kubectl -n "$NS" exec "$POD" -- env "PGPASSWORD=${TGT_PASS}" sh -c \
+    "psql -h '${TGT_HOST}' -U '${TGT_USER}' -d '${DB_NAME}' -c \"select email from profile limit 5;\""
+
+  log "Deleting migrator pod ${POD}..."
+  cleanup_pod "$POD"
+
+  log "Scaling up Penpot deployments to 1..."
+  scale_penpot 1
+  rollout_penpot || true
+
+  log "Migration completed (data copied Bitnami -> CNPG)."
+
+  if [[ "$DO_SWITCH" == "true" ]]; then
+    log "Switching Penpot to CNPG (cnpg.useAsPrimary=true) and disabling Bitnami..."
+    helm upgrade --install "$RELEASE" "$CHART_DIR" -n "$NS" \
+      --set global.cnpg.enabled=true \
+      --set global.cnpg.useAsPrimary=true \
+      --set global.postgresqlEnabled=false
+    log "Done. Penpot should now use CNPG."
+  else
+    echo
+    echo "--------------------------------------------------------------------------------"
+    echo "NEXT STEP (manual switch AFTER you verify CNPG data):"
+    echo
+    echo "  helm upgrade --install ${RELEASE} ${CHART_DIR} -n ${NS} \\"
+    echo "    --set global.cnpg.enabled=true \\"
+    echo "    --set global.cnpg.useAsPrimary=true \\"
+    echo "    --set global.postgresqlEnabled=false \\"
+    echo "    --set global.valkeyEnabled=true"
+    echo
+    echo "Tip: before switching, verify CNPG contains what you expect:"
+    echo "  kubectl -n ${NS} run -it --rm psql-tgt --image=postgres:16-alpine --restart=Never \\"
+    echo "    --env=\"PGPASSWORD=<CNPG_PASSWORD>\" -- sh -c \\"
+    echo "    'psql -h ${TGT_HOST} -U ${TGT_USER} -d ${DB_NAME} -c \"select email from profile;\"'"
+    echo "--------------------------------------------------------------------------------"
+    echo
+  fi
+}
+
+main "$@"
+


### PR DESCRIPTION
![Texto alternativo](
https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGIwcmN3ZWpoNWZzOWR6OHVkY29nZTdkMHJvdjdodDNram9iMm1hZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8EmeieJAGjvUI/giphy.gif)

This PR adds support for using **CloudNativePG (CNPG)** as the PostgreSQL backend for the Penpot Helm chart, introducing an explicit and safe migration path from the existing Bitnami PostgreSQL setup. New global configuration flags allow deploying CNPG alongside Bitnami PostgreSQL, running both during a migration phase, and switching Penpot to use CNPG as the primary database only when explicitly requested. Bitnami PostgreSQL is now deprecated and will be supported for a limited number of releases, but existing installations continue to work unchanged unless the new flags are enabled and the migration process is manually executed.
