### PR TITLE
:books: Add deprecation warning for Bitnami in 1.0.0

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -39,6 +39,10 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: changed
+      description: "Add deprecation warning for Bitnami PostgreSQL and Valkey. These options will be deprecated in 1.0.0."
+    - kind: added
+      description: "Improve the documentation with basic requirements necessary for Penpot setup" 
 dependencies:
   - name: postgresql
     version: 15.5.38 # default appVersion 16.4.0

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -10,6 +10,35 @@ Penpot is the first **open-source** design tool for design and code collaboratio
 
 Penpot is available on browser and [self host](https://penpot.app/self-host). It’s web-based and works with open standards (SVG, CSS and HTML). And last but not least, it’s free!
 
+## Prerequisites
+
+Penpot requires the following external services to be available before installing the chart:
+
+- **PostgreSQL** (v15 or higher recommended): Penpot uses PostgreSQL as its primary database for storing all application data (users, projects, files, etc.). You must have a running PostgreSQL instance accessible from the Kubernetes cluster.
+- **Valkey** (or a compatible Redis® instance): Penpot uses Valkey as an in-memory data store for caching, session management and real-time communication between components. You must have a running Valkey (or Redis®) instance accessible from the Kubernetes cluster.
+
+### How to provision PostgreSQL and Valkey
+
+Here are some recommended methods to set up these dependencies:
+
+#### PostgreSQL
+
+| Method | Description |
+|--------|-------------|
+| **Bitnami Helm Chart** | Deploy PostgreSQL in the same Kubernetes cluster using the [Bitnami PostgreSQL chart](https://artifacthub.io/packages/helm/bitnami/postgresql). Quick setup: `helm install my-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql --set auth.username=penpot --set auth.password=penpot --set auth.database=penpot` |
+| **CloudNativePG Operator** | Use the [CloudNativePG](https://cloudnative-pg.io/) Kubernetes operator for production-grade PostgreSQL with automated failover, backups and high availability. |
+| **Managed cloud services** | Use a managed PostgreSQL service from your cloud provider: [Amazon RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/), [Azure Database for PostgreSQL](https://azure.microsoft.com/products/postgresql/), [Google Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres), or [DigitalOcean Managed Databases](https://www.digitalocean.com/products/managed-databases-postgresql). |
+| **Docker / VM** | Run PostgreSQL on a separate server or VM outside of Kubernetes and expose it via a reachable hostname or IP. |
+
+#### Valkey
+
+| Method | Description |
+|--------|-------------|
+| **Bitnami Helm Chart** | Deploy Valkey in the same Kubernetes cluster using the [Bitnami Valkey chart](https://artifacthub.io/packages/helm/bitnami/valkey). Quick setup: `helm install my-valkey oci://registry-1.docker.io/bitnamicharts/valkey --set architecture=standalone --set auth.enabled=false` |
+| **Managed cloud services** | Use a managed Redis®-compatible service: [Amazon ElastiCache for Redis](https://aws.amazon.com/elasticache/redis/), [Azure Cache for Redis](https://azure.microsoft.com/products/cache/), [Google Cloud Memorystore](https://cloud.google.com/memorystore), or [DigitalOcean Managed Redis](https://www.digitalocean.com/products/managed-databases-redis). |
+| **Docker / VM** | Run Valkey (or Redis®) on a separate server or VM and expose it via a reachable hostname or IP. |
+
+> **Note**: Penpot only requires a standalone Valkey/Redis® instance. Cluster or replication mode is not necessary.
 
 ## Installing the Chart
 
@@ -20,20 +49,47 @@ $ helm repo add penpot http://helm.penpot.app
 $ helm install my-release penpot/{{ template "chart.name" . }}
 ```
 
-You can customize the installation specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+To customize the installation, you can specify each parameter by passing the argument `--set key=value[,key=value]` in the `helm install` command. 
 
-```console
+Provide the connection details of your PostgreSQL and Valkey instances during installation, For example,
+```
 helm install my-release \
-  --set global.postgresqlEnabled=true \
-  --set global.valkeyEnabled=true \
+  --set config.postgresql.host=<your-postgresql-host> \
+  --set config.postgresql.port=5432 \
+  --set config.postgresql.database=penpot \
+  --set config.postgresql.username=penpot \
+  --set config.postgresql.password=<your-postgresql-password> \
+  --set config.redis.host=<your-valkey-host> \
+  --set config.redis.port=6379 \
+  --set config.redis.database=0 \
   --set persistence.assets.enabled=true \
   penpot/{{ template "chart.name" . }}
 ```
+> **Note:** Replace `<your-postgresql-host>`, `<your-postgresql-password>` and `<your-valkey-host>` with the actual values of your instances.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
 helm install my-release -f values.yaml penpot/{{ template "chart.name" . }}
+```
+An example values.yaml for external instances:
+
+```yml
+config:
+  postgresql:
+    host: "my-postgresql.example.com"
+    port: 5432
+    database: "penpot"
+    username: "penpot"
+    password: "my-secret-password"
+  redis:
+    host: "my-valkey.example.com"
+    port: 6379
+    database: "0"
+
+persistence:
+  assets:
+    enabled: true
 ```
 > **Tip**: You can use the default values.yaml
 
@@ -191,47 +247,6 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}
-
-
-### PostgreSQL
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-{{- range .Values }}
-  {{- if hasPrefix "postgresql" .Key }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
-  {{- end }}
-{{- end }}
-
-> **NOTE**: You can use more parameters according to the [PostgreSQL oficial documentation](https://artifacthub.io/packages/helm/bitnami/postgresql#parameters).
-
-
-### Valkey
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-{{- range .Values }}
-  {{- if hasPrefix "valkey" .Key }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
-  {{- end }}
-{{- end }}
-
-> **NOTE**: You can use more parameters according to the [Valkey oficial documentation](https://artifacthub.io/packages/helm/bitnami/valkey#parameters).
-
-
-### Redis
-
-> **DEPRECATION WARNING:** Since penpot 2.8, Penpot has migrated from Redis to Velkey. Although migration is recommended. Penpot will work seamlessly with compatible Redis versions. 
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-{{- range .Values }}
-  {{- if hasPrefix "redis" .Key }}
-| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
-  {{- end }}
-{{- end }}
-
-> **NOTE**: You can use more parameters according to the [Redis oficial documentation](https://artifacthub.io/packages/helm/bitnami/redis#parameters).
 
 
 ## Upgrading

--- a/charts/penpot/templates/NOTES.txt
+++ b/charts/penpot/templates/NOTES.txt
@@ -9,10 +9,14 @@
     $ helm status {{ .Release.Name }}
     $ helm get all {{ .Release.Name }}
   
-  {{- if .Values.global.redisEnabled }}
+  {{- if or .Values.global.postgresqlEnabled .Values.global.valkeyEnabled .Values.global.redisEnabled }}
 
-  DEPRECATION WARNING: 
-     Since Penpot 2.8, Penpot has migrated from Redis to Valkey. 
-     Although migration is recommended, Penpot will work seamlessly
-     with compatible Redis versions.
+
+  ⚠️  DEPRECATION WARNING: 
+     🚨 Bitnami-based dependencies are supported only until the last release prior to 1.0.0.
+
+     Starting from version 1.0.0, they will be officially deprecated and no longer maintained by Penpot team
+
+     👉 Please migrate to the supported architecture before upgrading to 1.0.0.
+
   {{- end }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -2,15 +2,26 @@
 ## Default values for Penpot
 
 global:
-  # -- Whether to deploy the Bitnami PostgreSQL chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/postgresql) for configuration.
-  # @section -- Global parameters
+  # Whether to deploy the Bitnami PostgreSQL chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/postgresql) for configuration.
+  # ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
+  # Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated
+  # starting from chart version 1.0.0 and will no longer be maintained
+  # by Penpot team
+  # @ignore
   postgresqlEnabled: false
-  # -- Whether to deploy the Bitnami Valkey chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/valkey) for configuration.
-  # @section -- Global parameters
+  # Whether to deploy the Bitnami Valkey chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/valkey) for configuration.
+  # ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
+  # Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated
+  # starting from chart version 1.0.0 and will no longer be maintained
+  # by Penpot team
+  # @ignore
   valkeyEnabled: false
-  # -- Whether to deploy the Bitnami Redis chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/redis) for configuration.
-  # *DEPRECATION WARNING: Since Penpot 2.8, Penpot has migrated from Redis to Valkey. Although migration is recommended, Penpot will work seamlessly with compatible Redis versions. 
-  # @section -- Global parameters
+  # Whether to deploy the Bitnami Redis chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/redis) for configuration.
+  # ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
+  # Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated
+  # starting from chart version 1.0.0 and will no longer be maintained
+  # by Penpot team
+  # @ignore
   redisEnabled: false
   # -- Global Docker registry secret names.
   # E.g.
@@ -724,6 +735,10 @@ route:
   wildcardPolicy: None
 
 # PostgreSQL configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/postgresql))
+# ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
+# Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated
+# starting from chart version 1.0.0 and will no longer be maintained
+# by Penpot team
 postgresql:
   image:
     repository: bitnamilegacy/postgresql
@@ -731,22 +746,22 @@ postgresql:
   global:
     compatibility:
       openshift:
-        # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
-        # @section -- PostgreSQL Dependencie parameters
+        # Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         adaptSecurityContext: "auto"
 
   auth:
-    # -- Name for a custom user to create.
-    # @section -- PostgreSQL Dependencie parameters
+    # Name for a custom user to create.
     username: "penpot"
-    # -- Password for the custom user to create.
-    # @section -- PostgreSQL Dependencie parameters
+    # Password for the custom user to create.
     password: "penpot"
-    # -- Name for a custom database to create.
-    # @section -- PostgreSQL Dependencie parameters
+    # Name for a custom database to create.
     database: "penpot"
 
 # Valkey configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/valkey))
+# ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
+# Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated
+# starting from chart version 1.0.0 and will no longer be maintained
+# by Penpot team
 valkey:
   image:
     repository: bitnamilegacy/valkey
@@ -754,18 +769,14 @@ valkey:
   global:
     compatibility:
       openshift:
-        # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
-        # @section -- Valkey Dependencie parameters
+        # Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         adaptSecurityContext: "auto"
   auth:
-    # -- Whether to enable password authentication.
-    # @section -- Valkey Dependencie parameters
+    # Whether to enable password authentication.
     enabled: false
-  # -- Valkey architecture. Allowed values: `standalone` or `replication`. Penpot only needs a standalone Valkey StatefulSet. Check for [more info here](https://artifacthub.io/packages/helm/bitnami/vlakey#cluster-topologies)
-  # @section -- Valkey Dependencie parameters
+  # Valkey architecture. Allowed values: `standalone` or `replication`. Penpot only needs a standalone Valkey StatefulSet. Check for [more info here](https://artifacthub.io/packages/helm/bitnami/vlakey#cluster-topologies)
   architecture: standalone
-  # -- Common configuration to be appended to valkey.conf (as a block of configuration lines).
-  # @section -- Valkey Dependencie parameters
+  # Common configuration to be appended to valkey.conf (as a block of configuration lines).
   commonConfiguration: |
     ## Recommended values for most Penpot instances. 
     ## You can modify this value to follow your policies.
@@ -785,6 +796,10 @@ valkey:
 
 # Redis configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/redis))
 # DEPRECATION WARNING: Since Penpot 2.8, Penpot has migrated from Redis to Velkey. Although migration is recommended. Penpot will work seamlessly with compatible Redis versions. 
+# ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
+# Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated
+# starting from chart version 1.0.0 and will no longer be maintained
+# by Penpot team
 redis:
   image:
     repository: bitnamilegacy/redis
@@ -792,18 +807,14 @@ redis:
   global:
     compatibility:
       openshift:
-        # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
-        # @section -- Redis Dependencie parameters
+        # Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
         adaptSecurityContext: "auto"
   auth:
-    # -- Whether to enable password authentication.
-    # @section -- Redis Dependencie parameters
+    # Whether to enable password authentication.
     enabled: false
-  # -- Redis® architecture. Allowed values: `standalone` or `replication`. Penpot only needs a standalone Redis® StatefulSet. Check for [more info here](https://artifacthub.io/packages/helm/bitnami/redis#cluster-topologies)
-  # @section -- Redis Dependencie parameters
+  # Redis® architecture. Allowed values: `standalone` or `replication`. Penpot only needs a standalone Redis® StatefulSet. Check for [more info here](https://artifacthub.io/packages/helm/bitnami/redis#cluster-topologies)
   architecture: standalone
-  # -- Common configuration to be appended to redis.conf (as a block of configuration lines).
-  # @section -- Redis Dependencie parameters
+  # Common configuration to be appended to redis.conf (as a block of configuration lines).
   commonConfiguration: |
     ## Recommended values for most Penpot instances.
     ## You can modify this value to follow your policies.


### PR DESCRIPTION
![Texto alternativo](
https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExbmwybjIzemZjenJ2cDVyZXpnNzVycDg4NmRyZHdmdWJ4d3Y5d3ExaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jnQYWZ0T4mkhCmkzcn/giphy.gif)

This PR adds a deprecation warning for Bitnami-based dependencies.

They will remain supported only until the last release prior to 1.0.0.
Starting from version 1.0.0, they will no longer be maintained.

No functional changes are introduced. The warning is displayed during `helm install` and `helm upgrade`.
