### PR TITLE
feat: add HPA and VPA support for backend, frontend and exporter

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.36.0  # Chart version
+version: 0.37.0-unreleased  # Chart version
 appVersion: "2.14.0"  # Penpot version
 type: application
 name: penpot
@@ -39,12 +39,8 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump Penpot to 2.14.0
-    - kind: changed
-      description: "Add deprecation warning for Bitnami PostgreSQL and Valkey. These options will be deprecated in 1.0.0."
     - kind: added
-      description: "Improve the documentation with basic requirements necessary for Penpot setup" 
+      description: Add HPA and VPA support for backend, frontend and exporter 
 dependencies:
   - name: postgresql
     version: 15.5.38 # default appVersion 16.4.0

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -1,6 +1,6 @@
 # penpot
 
-![Version: 0.36.0](https://img.shields.io/badge/Version-0.36.0-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.37.0-unreleased](https://img.shields.io/badge/Version-0.37.0--unreleased-informational?style=flat-square) ![AppVersion: 2.14.0](https://img.shields.io/badge/AppVersion-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart for Penpot, the Open Source design and prototyping platform.
 
@@ -261,6 +261,14 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
+| backend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the backend pods. |
+| backend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the backend. When enabled, replicaCount is ignored. |
+| backend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of backend replicas. |
+| backend.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
+| backend.autoscaling.hpa.minReplicas | int | `1` | Minimum number of backend replicas. |
+| backend.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the backend. Requires VPA operator installed in the cluster. |
+| backend.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the backend containers. |
+| backend.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | backend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | backend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | backend.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
@@ -292,6 +300,14 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | frontend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
+| frontend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the frontend pods. |
+| frontend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the frontend. When enabled, replicaCount is ignored. |
+| frontend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of frontend replicas. |
+| frontend.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
+| frontend.autoscaling.hpa.minReplicas | int | `1` | Minimum number of frontend replicas. |
+| frontend.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the frontend. Requires VPA operator installed in the cluster. |
+| frontend.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the frontend containers. |
+| frontend.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | frontend.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the frontend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
@@ -322,6 +338,14 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | exporter.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
+| exporter.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the exporter pods. |
+| exporter.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the exporter. When enabled, replicaCount is ignored. |
+| exporter.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of exporter replicas. |
+| exporter.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
+| exporter.autoscaling.hpa.minReplicas | int | `1` | Minimum number of exporter replicas. |
+| exporter.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the exporter. Requires VPA operator installed in the cluster. |
+| exporter.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the exporter containers. |
+| exporter.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | exporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | exporter.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | exporter.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -13,7 +13,9 @@ spec:
   selector:
     matchLabels:
       {{- include "penpot.backendSelectorLabels" . | nindent 6 }}
+  {{- if not .Values.backend.autoscaling.hpa.enabled }}
   replicas: {{ .Values.backend.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/penpot/templates/backend-hpa.yml
+++ b/charts/penpot/templates/backend-hpa.yml
@@ -1,0 +1,18 @@
+{{- if .Values.backend.autoscaling.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "penpot.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "penpot.fullname" . }}-backend
+  minReplicas: {{ .Values.backend.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.backend.autoscaling.hpa.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.backend.autoscaling.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/charts/penpot/templates/backend-vpa.yml
+++ b/charts/penpot/templates/backend-vpa.yml
@@ -1,0 +1,20 @@
+{{- if .Values.backend.autoscaling.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "penpot.fullname" . }}-backend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "penpot.fullname" . }}-backend
+  updatePolicy:
+    updateMode: {{ .Values.backend.autoscaling.vpa.updateMode | quote }}
+  {{- with .Values.backend.autoscaling.vpa.resourcePolicy }}
+  resourcePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/penpot/templates/exporter-deployment.yml
+++ b/charts/penpot/templates/exporter-deployment.yml
@@ -10,7 +10,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.exporter.autoscaling.hpa.enabled }}
   replicas: {{ .Values.exporter.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "penpot.exporterSelectorLabels" . | nindent 6 }}

--- a/charts/penpot/templates/exporter-hpa.yml
+++ b/charts/penpot/templates/exporter-hpa.yml
@@ -1,0 +1,18 @@
+{{- if .Values.exporter.autoscaling.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "penpot.fullname" . }}-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "penpot.fullname" . }}-exporter
+  minReplicas: {{ .Values.exporter.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.exporter.autoscaling.hpa.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.exporter.autoscaling.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/charts/penpot/templates/exporter-vpa.yml
+++ b/charts/penpot/templates/exporter-vpa.yml
@@ -1,0 +1,20 @@
+{{- if .Values.exporter.autoscaling.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "penpot.fullname" . }}-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "penpot.fullname" . }}-exporter
+  updatePolicy:
+    updateMode: {{ .Values.exporter.autoscaling.vpa.updateMode | quote }}
+  {{- with .Values.exporter.autoscaling.vpa.resourcePolicy }}
+  resourcePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/penpot/templates/frontend-deployment.yml
+++ b/charts/penpot/templates/frontend-deployment.yml
@@ -13,7 +13,9 @@ spec:
   selector:
     matchLabels:
       {{- include "penpot.frontendSelectorLabels" . | nindent 6 }}
+  {{- if not .Values.frontend.autoscaling.hpa.enabled }}
   replicas: {{ .Values.frontend.replicaCount }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/penpot/templates/frontend-hpa.yml
+++ b/charts/penpot/templates/frontend-hpa.yml
@@ -1,0 +1,18 @@
+{{- if .Values.frontend.autoscaling.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "penpot.fullname" . }}-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "penpot.fullname" . }}-frontend
+  minReplicas: {{ .Values.frontend.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.frontend.autoscaling.hpa.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.frontend.autoscaling.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/charts/penpot/templates/frontend-vpa.yml
+++ b/charts/penpot/templates/frontend-vpa.yml
@@ -1,0 +1,20 @@
+{{- if .Values.frontend.autoscaling.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "penpot.fullname" . }}-frontend
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "penpot.fullname" . }}-frontend
+  updatePolicy:
+    updateMode: {{ .Values.frontend.autoscaling.vpa.updateMode | quote }}
+  {{- with .Values.frontend.autoscaling.vpa.resourcePolicy }}
+  resourcePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -450,6 +450,44 @@ backend:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Backend parameters
     maxUnavailable:
+  # -- Configure autoscaling for the backend pods.
+  # @section -- Backend parameters
+  autoscaling:
+    hpa:
+      # -- Enable Horizontal Pod Autoscaler for the backend. When enabled, replicaCount is ignored.
+      # @section -- Backend parameters
+      enabled: false
+      # -- Minimum number of backend replicas.
+      # @section -- Backend parameters
+      minReplicas: 1
+      # -- Maximum number of backend replicas.
+      # @section -- Backend parameters
+      maxReplicas: 5
+      # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+      # @section -- Backend parameters
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 70
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 80
+    vpa:
+      # -- Enable Vertical Pod Autoscaler for the backend. Requires VPA operator installed in the cluster.
+      # @section -- Backend parameters
+      enabled: false
+      # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
+      # @section -- Backend parameters
+      updateMode: "Auto"
+      # -- VPA resource policy for the backend containers.
+      # @section -- Backend parameters
+      resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
   # @section -- Backend parameters
   extraEnvs: []
@@ -537,6 +575,44 @@ frontend:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Frontend parameters
     maxUnavailable:
+  # -- Configure autoscaling for the frontend pods.
+  # @section -- Frontend parameters
+  autoscaling:
+    hpa:
+      # -- Enable Horizontal Pod Autoscaler for the frontend. When enabled, replicaCount is ignored.
+      # @section -- Frontend parameters
+      enabled: false
+      # -- Minimum number of frontend replicas.
+      # @section -- Frontend parameters
+      minReplicas: 1
+      # -- Maximum number of frontend replicas.
+      # @section -- Frontend parameters
+      maxReplicas: 5
+      # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+      # @section -- Frontend parameters
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 70
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 80
+    vpa:
+      # -- Enable Vertical Pod Autoscaler for the frontend. Requires VPA operator installed in the cluster.
+      # @section -- Frontend parameters
+      enabled: false
+      # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
+      # @section -- Frontend parameters
+      updateMode: "Auto"
+      # -- VPA resource policy for the frontend containers.
+      # @section -- Frontend parameters
+      resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the frontend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
   # @section -- Frontend parameters
   extraEnvs: []
@@ -624,6 +700,44 @@ exporter:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Exporter parameters
     maxUnavailable:
+  # -- Configure autoscaling for the exporter pods.
+  # @section -- Exporter parameters
+  autoscaling:
+    hpa:
+      # -- Enable Horizontal Pod Autoscaler for the exporter. When enabled, replicaCount is ignored.
+      # @section -- Exporter parameters
+      enabled: false
+      # -- Minimum number of exporter replicas.
+      # @section -- Exporter parameters
+      minReplicas: 1
+      # -- Maximum number of exporter replicas.
+      # @section -- Exporter parameters
+      maxReplicas: 5
+      # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+      # @section -- Exporter parameters
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 70
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 80
+    vpa:
+      # -- Enable Vertical Pod Autoscaler for the exporter. Requires VPA operator installed in the cluster.
+      # @section -- Exporter parameters
+      enabled: false
+      # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
+      # @section -- Exporter parameters
+      updateMode: "Auto"
+      # -- VPA resource policy for the exporter containers.
+      # @section -- Exporter parameters
+      resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
   # @section -- Exporter parameters
   extraEnvs: []


### PR DESCRIPTION
The chart had no native autoscaling support — HPA/VPA had to be managed as external resources. This adds first-class HPA and VPA support for all three components, fully opt-in and backwards compatible.

## Changes

- **Deployment templates** (`backend`, `frontend`, `exporter`): `replicas` is now conditionally omitted when HPA is enabled, preventing `helm upgrade` from overriding HPA-managed replica counts
- **6 new templates**: `{backend,frontend,exporter}-hpa.yml` (`autoscaling/v2`) and `{backend,frontend,exporter}-vpa.yml` (`autoscaling.k8s.io/v1`)
- **`values.yaml`**: Added `autoscaling.hpa` and `autoscaling.vpa` blocks under each component — all default to `enabled: false`

## Usage

```yaml
backend:
  autoscaling:
    hpa:
      enabled: true
      minReplicas: 2
      maxReplicas: 10
      metrics:
        - type: Resource
          resource:
            name: cpu
            target:
              type: Utilization
              averageUtilization: 70
    vpa:
      enabled: false
      updateMode: "Auto"  # "Off" for recommendations only
      resourcePolicy: {}
```

VPA requires the [VPA operator](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) installed in the cluster.

<details>

<summary>Original prompt</summary>


## Add HPA (HorizontalPodAutoscaler) and VPA (VerticalPodAutoscaler) support

The chart currently has no support for HPA or VPA. This PR adds native support for both autoscalers for all three components: `backend`, `frontend`, and `exporter`.

---

### Changes required

#### 1. Modify existing Deployment templates to conditionally omit `replicas` when HPA is enabled

When HPA is active, the `replicas` field must NOT be set in the Deployment, otherwise every `helm upgrade` will override the HPA's replica count.

**`charts/penpot/templates/backend-deployment.yml`** — change line 16:
```yaml
# Before:
  replicas: {{ .Values.backend.replicaCount }}

# After:
  {{- if not .Values.backend.autoscaling.hpa.enabled }}
  replicas: {{ .Values.backend.replicaCount }}
  {{- end }}
```

**`charts/penpot/templates/frontend-deployment.yml`** — change line 16:
```yaml
# Before:
  replicas: {{ .Values.frontend.replicaCount }}

# After:
  {{- if not .Values.frontend.autoscaling.hpa.enabled }}
  replicas: {{ .Values.frontend.replicaCount }}
  {{- end }}
```

**`charts/penpot/templates/exporter-deployment.yml`** — change line 13:
```yaml
# Before:
  replicas: {{ .Values.exporter.replicaCount }}

# After:
  {{- if not .Values.exporter.autoscaling.hpa.enabled }}
  replicas: {{ .Values.exporter.replicaCount }}
  {{- end }}
```

---

#### 2. Create 6 new template files

**`charts/penpot/templates/backend-hpa.yml`**:
```yaml
{{- if .Values.backend.autoscaling.hpa.enabled }}
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: {{ include "penpot.fullname" . }}-backend
  namespace: {{ .Release.Namespace }}
  labels:
    {{- include "penpot.labels" . | nindent 4 }}
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: {{ include "penpot.fullname" . }}-backend
  minReplicas: {{ .Values.backend.autoscaling.hpa.minReplicas }}
  maxReplicas: {{ .Values.backend.autoscaling.hpa.maxReplicas }}
  metrics:
    {{- toYaml .Values.backend.autoscaling.hpa.metrics | nindent 4 }}
{{- end }}
```

**`charts/penpot/templates/backend-vpa.yml`**:
```yaml
{{- if .Values.backend.autoscaling.vpa.enabled }}
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: {{ include "penpot.fullname" . }}-backend
  namespace: {{ .Release.Namespace }}
  labels:
    {{- include "penpot.labels" . | nindent 4 }}
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: {{ include "penpot.fullname" . }}-backend
  updatePolicy:
    updateMode: {{ .Values.backend.autoscaling.vpa.updateMode | quote }}
  {{- with .Values.backend.autoscaling.vpa.resourcePolicy }}
  resourcePolicy:
    {{- toYaml . | nindent 4 }}
  {{- end }}
{{- end }}
```

**`charts/penpot/templates/frontend-hpa.yml`**:
```yaml
{{- if .Values.frontend.autoscaling.hpa.enabled }}
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: {{ include "penpot.fullname" . }}-frontend
  namespace: {{ .Release.Namespace }}
  labels:
    {{- include "penpot.labels" . | nindent 4 }}
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: {{ include "penpot.fullname" . }}-frontend
  minReplicas: {{ .Values.frontend.autoscaling.hpa.minReplicas }}
  maxReplicas: {{ .Values.frontend.autoscaling.hpa.maxReplicas }}
  metrics:
    {{- toYaml .Values.frontend.autoscaling.hpa.metrics | nindent 4 }}
{{- end }}
```

**`charts/penpot/templates/frontend-vpa.yml`**:
```yaml
{{- if .Values.frontend.autoscaling.vpa.enabled }}
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: {{ include "penpot.fullname" . }}-frontend
  namespace: {{ .Release.Namespace }}
  labels:
    {{- include "penpot.labels" . | nindent 4 }}
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: {{ include "penpot.fullname" . }}-frontend
  updatePolicy:
    updateMode: {{ .Values.frontend.autoscaling.vpa.updateMode | quote }}
  {{- with .Values.frontend.autoscaling.vpa.resourcePolicy }}
  resourcePolicy:
    {{- toYaml . | nindent 4 }}
  {{- end }}
{{- end }}
```

**`charts/penpot/templates/exporter-hpa.yml`**:
```yaml
{{- if .Values.exporter.autoscaling.hpa.enabled }}
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: {{ include "penpot.fullname" . }}-exporter
  namespace: {{ .Release.Namespace }}
  labels:
    {{- include "penpot.labels" . | nindent 4 }}
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: {{ include "penpot.fullname" . }}-exporter
  minReplicas: {{ .Values.exporter.autoscaling.hpa.minReplicas }}
  maxReplicas: {{ .Values.exporter.autoscaling.hpa.maxReplicas }}
  metrics:
    {{- toYaml .Values.exporter.autoscaling.hpa.metrics | nindent 4 }}
{{- end }}
```

**`charts/penpot/templates/exporter-vpa.yml`**:
```yaml
{{- if .Values.exporter.autoscaling.vpa.enabled }}
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  name: {{ include "penpot.fullname" . }}-exporter
  namespace: {{ .Release.Namespace }}
 ...

</details>