### PR TITLE
docs: warn about MCP high-availability limitations

### DIFF
--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -93,6 +93,12 @@ persistence:
 ```
 > **Tip**: You can use the default values.yaml
 
+### MCP Limitation
+
+> **Warning**
+> Starting with Penpot 2.15, the MCP integration does not currently support high-availability deployments.
+> Keep Penpot components as single replicas and do not enable HPA for frontend, backend or exporter while MCP is in use.
+
 ### 🔐 OpenShift Requirements
 
 If you are deploying on OpenShift, you may need to allow the pods to run with the `anyuid` Security Context Constraint (SCC). 
@@ -261,7 +267,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| backend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the backend pods. |
+| backend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the backend pods. Do not enable HPA when using the Penpot MCP integration because high availability is not currently supported. |
 | backend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the backend. When enabled, replicaCount is ignored. |
 | backend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of backend replicas. |
 | backend.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
@@ -283,7 +289,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | backend.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
 | backend.podLabels | object | `{}` | An optional map of labels to be applied to the controller Pods |
 | backend.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| backend.replicaCount | int | `1` | The number of replicas to deploy. |
+| backend.replicaCount | int | `1` | The number of replicas to deploy. If you enable the Penpot MCP integration, keep this value at 1 because high availability is not currently supported. |
 | backend.resources | object | `{"limits":{},"requests":{}}` | Penpot backend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
 | backend.resources.limits | object | `{}` | The resources limits for the Penpot backend containers |
 | backend.resources.requests | object | `{}` | The requested resources for the Penpot backend containers |
@@ -301,7 +307,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | frontend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| frontend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the frontend pods. |
+| frontend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the frontend pods. Do not enable HPA when using the Penpot MCP integration because high availability is not currently supported. |
 | frontend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the frontend. When enabled, replicaCount is ignored. |
 | frontend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of frontend replicas. |
 | frontend.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
@@ -323,7 +329,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | frontend.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
 | frontend.podLabels | object | `{}` | An optional map of labels to be applied to the controller Pods |
 | frontend.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| frontend.replicaCount | int | `1` | The number of replicas to deploy. |
+| frontend.replicaCount | int | `1` | The number of replicas to deploy. If you enable the Penpot MCP integration, keep this value at 1 because high availability is not currently supported. |
 | frontend.resources | object | `{"limits":{},"requests":{}}` | Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
 | frontend.resources.limits | object | `{}` | The resources limits for the Penpot frontend containers |
 | frontend.resources.requests | object | `{}` | The requested resources for the Penpot frontend containers |
@@ -340,7 +346,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | exporter.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| exporter.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the exporter pods. |
+| exporter.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the exporter pods. Do not enable HPA when using the Penpot MCP integration because high availability is not currently supported. |
 | exporter.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the exporter. When enabled, replicaCount is ignored. |
 | exporter.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of exporter replicas. |
 | exporter.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
@@ -362,7 +368,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | exporter.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
 | exporter.podLabels | object | `{}` | An optional map of labels to be applied to the controller Pods |
 | exporter.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
-| exporter.replicaCount | int | `1` | The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount |
+| exporter.replicaCount | int | `1` | The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount. If you enable the Penpot MCP integration, keep this value at 1 because high availability is not currently supported. |
 | exporter.resources | object | `{"limits":{},"requests":{}}` | Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
 | exporter.resources.limits | object | `{}` | The resources limits for the Penpot frontend containers |
 | exporter.resources.requests | object | `{}` | The requested resources for the Penpot frontend containers |

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -93,6 +93,12 @@ persistence:
 ```
 > **Tip**: You can use the default values.yaml
 
+### MCP Limitation
+
+> **Warning**
+> Starting with Penpot 2.15, the MCP integration does not currently support high-availability deployments.
+> Keep Penpot components as single replicas and do not enable HPA for frontend, backend or exporter while MCP is in use.
+
 ### 🔐 OpenShift Requirements
 
 If you are deploying on OpenShift, you may need to allow the pods to run with the `anyuid` Security Context Constraint (SCC).  

--- a/charts/penpot/templates/NOTES.txt
+++ b/charts/penpot/templates/NOTES.txt
@@ -8,6 +8,14 @@
   
     $ helm status {{ .Release.Name }}
     $ helm get all {{ .Release.Name }}
+
+
+  ⚠️  MCP WARNING:
+     Starting with Penpot 2.15, Penpot MCP integration does not currently
+     support high-availability deployments.
+
+     If you are using MCP, keep frontend, backend and exporter as single replicas
+     and do not enable HPA for those workloads.
   
   {{- if or .Values.global.postgresqlEnabled .Values.global.valkeyEnabled .Values.global.redisEnabled }}
 

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -376,7 +376,7 @@ backend:
     # -- The image pull policy to use.
     # @section -- Backend parameters
     pullPolicy: IfNotPresent
-  # -- The number of replicas to deploy.
+  # -- The number of replicas to deploy. If you enable the Penpot MCP integration, keep this value at 1 because high availability is not currently supported.
   # @section -- Backend parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
@@ -454,7 +454,7 @@ backend:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Backend parameters
     maxUnavailable:
-  # -- Configure autoscaling for the backend pods.
+  # -- Configure autoscaling for the backend pods. Do not enable HPA when using the Penpot MCP integration because high availability is not currently supported.
   # @section -- Backend parameters
   autoscaling:
     hpa:
@@ -513,7 +513,7 @@ frontend:
     # -- The image pull policy to use.
     # @section -- Frontend parameters
     pullPolicy: IfNotPresent
-  # -- The number of replicas to deploy.
+  # -- The number of replicas to deploy. If you enable the Penpot MCP integration, keep this value at 1 because high availability is not currently supported.
   # @section -- Frontend parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
@@ -583,7 +583,7 @@ frontend:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Frontend parameters
     maxUnavailable:
-  # -- Configure autoscaling for the frontend pods.
+  # -- Configure autoscaling for the frontend pods. Do not enable HPA when using the Penpot MCP integration because high availability is not currently supported.
   # @section -- Frontend parameters
   autoscaling:
     hpa:
@@ -642,7 +642,7 @@ exporter:
     # -- The image pull policy to use.
     # @section -- Exporter parameters
     imagePullPolicy: IfNotPresent
-  # -- The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount
+  # -- The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount. If you enable the Penpot MCP integration, keep this value at 1 because high availability is not currently supported.
   # @section -- Exporter parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
@@ -712,7 +712,7 @@ exporter:
     # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
     # @section -- Exporter parameters
     maxUnavailable:
-  # -- Configure autoscaling for the exporter pods.
+  # -- Configure autoscaling for the exporter pods. Do not enable HPA when using the Penpot MCP integration because high availability is not currently supported.
   # @section -- Exporter parameters
   autoscaling:
     hpa:


### PR DESCRIPTION
![s](https://media.tenor.com/D9G5GLTeodgAAAAi/chaos-on-fire.gif)
Add a warning to the Helm chart documentation and release notes to clarify that the Penpot MCP integration does not currently support high-
  availability deployments.

  The warning is now visible in:
  - `charts/penpot/README.md`
  - `charts/penpot/templates/NOTES.txt`
  - comments around `replicaCount` and `autoscaling` in `charts/penpot/values.yaml`
