### PR TITLE
Add OpenShift security context compatibility for Penpot workloads

### DIFF
--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -101,7 +101,20 @@ persistence:
 
 ### 🔐 OpenShift Requirements
 
-If you are deploying on OpenShift, you may need to allow the pods to run with the `anyuid` Security Context Constraint (SCC). 
+Penpot workloads use fixed `runAsUser` and `fsGroup` values by default. OpenShift `restricted-v2` rejects those IDs unless they belong to the namespace-assigned range.
+
+The chart can adapt automatically on OpenShift by omitting `runAsUser`, `runAsGroup`, and `fsGroup` from Penpot workloads and letting the platform assign allowed IDs:
+
+```console
+global:
+  compatibility:
+    openshift:
+      adaptSecurityContext: auto
+```
+
+This is the default behavior. You can also set it to `force` to apply the adaptation outside OpenShift, or `disabled` to keep the fixed IDs.
+
+If you explicitly need fixed IDs, you may need to allow the pods to run with the `anyuid` Security Context Constraint (SCC). 
 You can do this with the following command:
 
 ```console
@@ -110,7 +123,7 @@ oc adm policy add-scc-to-group anyuid system:serviceaccounts:<your-namespace>
 
 Replace <your-namespace> with the actual namespace, e.g. penpot.
 
-Alternatively, if you do not want to relax this security constraint, you can configure the container to use a specific UID allowed by OpenShift by setting it explicitly in the values file.
+Alternatively, if you do not want to relax this security constraint, you can configure the chart with a UID and GID from the namespace-assigned range.
 First, get the UID range assigned to your namespace:
 
 ```console
@@ -122,23 +135,35 @@ This will return a value like:
 ```console
 1000700000/10000
 ```
-From that range, you can pick a UID (e.g., 1000700000) and set it in your `values.yaml` like this:
+From that range, you can pick a UID/GID (e.g., `1000700000`) and set it in your `values.yaml` like this:
 
 ```console
 backend:
-  securityContext:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
     runAsUser: 1000700000
 
 frontend:
-  securityContext:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
     runAsUser: 1000700000
 
 exporter:
-  securityContext:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
+    runAsUser: 1000700000
+
+mcp:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
     runAsUser: 1000700000
 ```
 
-Replace `1000700000` with a valid UID from your namespace range.
+Replace `1000700000` with a valid UID/GID from your namespace range.
 This allows running the chart securely in OpenShift without granting anyuid permissions.
 
 </details>
@@ -149,6 +174,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| global.compatibility.openshift.adaptSecurityContext | string | `"auto"` |  |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names. E.g. imagePullSecrets:   - myRegistryKeySecretName |
 
 ### General

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -101,7 +101,20 @@ persistence:
 
 ### 🔐 OpenShift Requirements
 
-If you are deploying on OpenShift, you may need to allow the pods to run with the `anyuid` Security Context Constraint (SCC).  
+Penpot workloads use fixed `runAsUser` and `fsGroup` values by default. OpenShift `restricted-v2` rejects those IDs unless they belong to the namespace-assigned range.
+
+The chart can adapt automatically on OpenShift by omitting `runAsUser`, `runAsGroup`, and `fsGroup` from Penpot workloads and letting the platform assign allowed IDs:
+
+```console
+global:
+  compatibility:
+    openshift:
+      adaptSecurityContext: auto
+```
+
+This is the default behavior. You can also set it to `force` to apply the adaptation outside OpenShift, or `disabled` to keep the fixed IDs.
+
+If you explicitly need fixed IDs, you may need to allow the pods to run with the `anyuid` Security Context Constraint (SCC).  
 You can do this with the following command:
 
 ```console
@@ -110,7 +123,7 @@ oc adm policy add-scc-to-group anyuid system:serviceaccounts:<your-namespace>
 
 Replace <your-namespace> with the actual namespace, e.g. penpot.
 
-Alternatively, if you do not want to relax this security constraint, you can configure the container to use a specific UID allowed by OpenShift by setting it explicitly in the values file.
+Alternatively, if you do not want to relax this security constraint, you can configure the chart with a UID and GID from the namespace-assigned range.
 First, get the UID range assigned to your namespace:
 
 ```console
@@ -122,23 +135,35 @@ This will return a value like:
 ```console
 1000700000/10000
 ```
-From that range, you can pick a UID (e.g., 1000700000) and set it in your `values.yaml` like this:
+From that range, you can pick a UID/GID (e.g., `1000700000`) and set it in your `values.yaml` like this:
 
 ```console
 backend:
-  securityContext:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
     runAsUser: 1000700000
 
 frontend:
-  securityContext:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
     runAsUser: 1000700000
 
 exporter:
-  securityContext:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
+    runAsUser: 1000700000
+
+mcp:
+  podSecurityContext:
+    fsGroup: 1000700000
+  containerSecurityContext:
     runAsUser: 1000700000
 ```
 
-Replace `1000700000` with a valid UID from your namespace range.
+Replace `1000700000` with a valid UID/GID from your namespace range.
 This allows running the chart securely in OpenShift without granting anyuid permissions.
 
 </details>

--- a/charts/penpot/templates/_helpers.tpl
+++ b/charts/penpot/templates/_helpers.tpl
@@ -77,3 +77,56 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Whether Penpot workloads should adapt their securityContext for OpenShift.
+*/}}
+{{- define "penpot.openshift.adaptSecurityContext" -}}
+{{- $mode := default "auto" .Values.global.compatibility.openshift.adaptSecurityContext -}}
+{{- if eq $mode "force" -}}
+true
+{{- else if eq $mode "disabled" -}}
+false
+{{- else if or (.Capabilities.APIVersions.Has "route.openshift.io/v1") (.Capabilities.APIVersions.Has "route.openshift.io/v1/Route") -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end }}
+
+{{/*
+Render a pod securityContext, omitting only OpenShift-managed user/group IDs.
+Keep fsGroup because stateful workloads may still require it for writable PVCs.
+*/}}
+{{- define "penpot.podSecurityContext" -}}
+{{- $ctx := .ctx -}}
+{{- $values := .values -}}
+{{- if $values -}}
+  {{- $adapt := eq (include "penpot.openshift.adaptSecurityContext" $ctx) "true" -}}
+  {{- $render := $values -}}
+  {{- if $adapt -}}
+    {{- $render = omit $values "runAsGroup" -}}
+  {{- end -}}
+  {{- if gt (len $render) 0 -}}
+{{ toYaml $render }}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render a container securityContext, omitting OpenShift-managed IDs and
+runtime user checks when requested.
+*/}}
+{{- define "penpot.containerSecurityContext" -}}
+{{- $ctx := .ctx -}}
+{{- $values := .values -}}
+{{- if $values -}}
+  {{- $adapt := eq (include "penpot.openshift.adaptSecurityContext" $ctx) "true" -}}
+  {{- $render := $values -}}
+  {{- if $adapt -}}
+    {{- $render = omit $values "runAsUser" "runAsGroup" "runAsNonRoot" -}}
+  {{- end -}}
+  {{- if gt (len $render) 0 -}}
+{{ toYaml $render }}
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/penpot/templates/backend-deployment.yml
+++ b/charts/penpot/templates/backend-deployment.yml
@@ -36,17 +36,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.backend.podSecurityContext }}
+      {{- with (include "penpot.podSecurityContext" (dict "ctx" . "values" .Values.backend.podSecurityContext)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-backend
           image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
-          {{- with .Values.backend.containerSecurityContext }}
+          {{- with (include "penpot.containerSecurityContext" (dict "ctx" . "values" .Values.backend.containerSecurityContext)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           env:
             # General settings

--- a/charts/penpot/templates/exporter-deployment.yml
+++ b/charts/penpot/templates/exporter-deployment.yml
@@ -36,17 +36,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.exporter.podSecurityContext }}
+      {{- with (include "penpot.podSecurityContext" (dict "ctx" . "values" .Values.exporter.podSecurityContext)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-exporter
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.exporter.image.imagePullPolicy }}
-          {{- with .Values.exporter.containerSecurityContext }}
+          {{- with (include "penpot.containerSecurityContext" (dict "ctx" . "values" .Values.exporter.containerSecurityContext)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           env:
             - name: PENPOT_PUBLIC_URI

--- a/charts/penpot/templates/frontend-deployment.yml
+++ b/charts/penpot/templates/frontend-deployment.yml
@@ -36,17 +36,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.frontend.podSecurityContext }}
+      {{- with (include "penpot.podSecurityContext" (dict "ctx" . "values" .Values.frontend.podSecurityContext)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-frontend
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
-          {{- with .Values.frontend.containerSecurityContext }}
+          {{- with (include "penpot.containerSecurityContext" (dict "ctx" . "values" .Values.frontend.containerSecurityContext)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           env:
             - name: PENPOT_FLAGS

--- a/charts/penpot/templates/mcp-deployment.yml
+++ b/charts/penpot/templates/mcp-deployment.yml
@@ -36,17 +36,17 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.mcp.podSecurityContext }}
+      {{- with (include "penpot.podSecurityContext" (dict "ctx" . "values" .Values.mcp.podSecurityContext)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-mcp
           image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
           imagePullPolicy: {{ .Values.mcp.image.imagePullPolicy }}
-          {{- with .Values.mcp.containerSecurityContext }}
+          {{- with (include "penpot.containerSecurityContext" (dict "ctx" . "values" .Values.mcp.containerSecurityContext)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           env:
             - name: PENPOT_MCP_SERVER_PORT

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -2,6 +2,11 @@
 ## Default values for Penpot
 
 global:
+  compatibility:
+    openshift:
+      # Adapt Penpot workload securityContext sections to OpenShift restricted-v2 SCC by omitting runAsUser, runAsGroup and fsGroup and letting the platform assign allowed IDs. Possible values: auto (apply when an OpenShift Route API is detected), force (perform the adaptation always), disabled (do not perform adaptation)
+      # @section -- Global parameters
+      adaptSecurityContext: "auto"
   # Whether to deploy the Bitnami PostgreSQL chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/postgresql) for configuration.
   # ⚠️ DEPRECATION NOTICE (Chart 1.0.0)
   # Bitnami-based dependencies (PostgreSQL and Valkey) will be deprecated


### PR DESCRIPTION
![f](https://media1.tenor.com/m/E73aHdNnj2AAAAAC/yoriko-nikaidou.gif)
This PR fixes OpenShift deployment compatibility for Penpot workloads by adapting securityContext rendering for OpenShift while preserving the `fsGroup` needed for writable PVC-backed asset storage.
Without this, the backend could fail writing to `/opt/data/assets`, which broke export flows.

  ## Validation

  - validated on `crc` with a clean install from scratch
  - validated on `minikube` to confirm no regression
  - confirmed exports work successfully in both environments

  Closes [#8872](https://github.com/penpot/penpot/issues/8872)