### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "/charts/penpot"
+    target-branch: "develop"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      penpot-images:
+        patterns:
+          - "penpotapp/*"


### PR DESCRIPTION

![h](https://media.tenor.com/ubHbrdnmFkEAAAAi/skeleton-waiting-on-office-chair-skull-waiting-on-chair.gif)

  - Enables monthly updates for GitHub Actions.
  - Enables monthly updates for pre-commit hooks.
  - Enables monthly Docker image tag checks for the Penpot chart images under `charts/penpot`.
  - Targets update PRs to `develop`.