### PR TITLE
Adds optional Gateway API support to the Penpot Helm chart and local development setup

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -39,5 +39,5 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump Penpot to 2.17.0
+    - kind: added
+      description: Add optional Gateway API HTTPRoute support

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -465,6 +465,18 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | persistence.assets.size | string | `"20Gi"` | Penpot objects persistent Volume size. |
 | persistence.assets.storageClass | string | `""` | Penpot objects persistent Volume storage class. If defined, storageClassName: <storageClass>. If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner. |
 
+### Gateway API
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| gateway.annotations | object | `{}` | Extra annotations for the HTTPRoute. |
+| gateway.enabled | bool | `false` | Enable Gateway API HTTPRoute support. |
+| gateway.filters | list | `[]` | Optional filters for the HTTPRoute rules. Example: filters:   - type: RequestHeaderModifier     requestHeaderModifier:       set:         - name: X-Forwarded-Proto           value: https |
+| gateway.hostnames | list | `["penpot.example.com"]` | Hostnames exposed by the HTTPRoute. |
+| gateway.parentRefs | list | `[]` | ParentRefs for attaching the HTTPRoute to one or more Gateways. Example: parentRefs:   - name: shared-gateway     namespace: infra     sectionName: http |
+| gateway.path | string | `"/"` | Path value for the HTTPRoute match. |
+| gateway.pathMatchType | string | `"PathPrefix"` | Path match type for the HTTPRoute. Common values: PathPrefix, Exact |
+
 ### Ingress
 
 | Key | Type | Default | Description |

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -200,6 +200,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
     (hasPrefix "exporter" .Key)
     (hasPrefix "mcp" .Key)
     (hasPrefix "persistence" .Key)
+    (hasPrefix "gateway" .Key)
     (hasPrefix "ingress" .Key)
     (hasPrefix "route" .Key)
   ) }}
@@ -269,6 +270,17 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 |-----|------|---------|-------------|
 {{- range .Values }}
   {{- if hasPrefix "persistence" .Key }}
+| {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
+  {{- end }}
+{{- end }}
+
+
+### Gateway API
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+{{- range .Values }}
+  {{- if hasPrefix "gateway" .Key }}
 | {{ .Key }} | {{ .Type }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} |
   {{- end }}
 {{- end }}

--- a/charts/penpot/templates/httproute.yml
+++ b/charts/penpot/templates/httproute.yml
@@ -1,0 +1,36 @@
+{{- if and .Values.gateway.enabled (empty .Values.gateway.parentRefs) -}}
+{{- fail "gateway.enabled=true requires gateway.parentRefs to be set" -}}
+{{- end -}}
+{{- if .Values.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "penpot.fullname" . }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gateway.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.pathMatchType }}
+            value: {{ .Values.gateway.path | quote }}
+      {{- with .Values.gateway.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "penpot.fullname" . }}
+          port: {{ .Values.frontend.service.port }}
+{{- end }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -905,6 +905,49 @@ persistence:
     # @section -- Persistence parameters
     annotations: {}
 
+gateway:
+  # -- Enable Gateway API HTTPRoute support.
+  # @section -- Gateway API parameters
+  enabled: false
+
+  # -- Extra annotations for the HTTPRoute.
+  # @section -- Gateway API parameters
+  annotations: {}
+
+  # -- Hostnames exposed by the HTTPRoute.
+  # @section -- Gateway API parameters
+  hostnames:
+    - penpot.example.com
+
+  # -- ParentRefs for attaching the HTTPRoute to one or more Gateways.
+  # Example:
+  # parentRefs:
+  #   - name: shared-gateway
+  #     namespace: infra
+  #     sectionName: http
+  # @section -- Gateway API parameters
+  parentRefs: []
+
+  # -- Path match type for the HTTPRoute.
+  # Common values: PathPrefix, Exact
+  # @section -- Gateway API parameters
+  pathMatchType: PathPrefix
+
+  # -- Path value for the HTTPRoute match.
+  # @section -- Gateway API parameters
+  path: /
+
+  # -- Optional filters for the HTTPRoute rules.
+  # Example:
+  # filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #         - name: X-Forwarded-Proto
+  #           value: https
+  # @section -- Gateway API parameters
+  filters: []
+
 ingress:
   # -- Enable (frontend) Ingress Controller.
   # @section -- Ingress parameters

--- a/devel/README.md
+++ b/devel/README.md
@@ -17,7 +17,15 @@ pre-commit install --install-hooks -f
 
 ## Usage
 
-- Create the local cluster, namespace, ingress and local dependencies:
+Create the local cluster, namespace and local dependencies.
+
+Choose one exposure mode:
+- `ingress` (default)
+- `gateway`
+
+### Using Ingress (default)
+
+- Create the local cluster with ingress support:
   ```shell
   ./scripts/create_cluster.sh
   ```
@@ -25,6 +33,14 @@ pre-commit install --install-hooks -f
 - Create a local copy of the chart values:
   ```shell
   cp devel/penpot.values.yaml local.penpot.values.yaml
+  ```
+
+- Ensure the local values use:
+  ```yaml
+  ingress:
+    enabled: true
+  gateway:
+    enabled: false
   ```
 
 - Install the chart:
@@ -44,6 +60,56 @@ pre-commit install --install-hooks -f
 
 - Access the application at [http://penpot.example.com/](http://penpot.example.com/)
 
+### Using Gateway API
+
+- Create the local cluster with Gateway API support:
+  ```shell
+  EXPOSURE_MODE=gateway ./scripts/create_cluster.sh
+  ```
+
+- Create a local copy of the chart values:
+  ```shell
+  cp devel/penpot.values.yaml local.penpot.values.yaml
+  ```
+
+- Ensure the local values use:
+  ```yaml
+  config:
+    publicUri: "http://penpot.example.com:8888"
+  ingress:
+    enabled: false
+  gateway:
+    enabled: true
+    parentRefs:
+      - name: penpot
+        namespace: penpot
+        sectionName: http
+    hostnames:
+      - "penpot.example.com"
+  ```
+
+- Install the chart:
+  ```shell
+  helm install penpot ./charts/penpot -n penpot -f local.penpot.values.yaml
+  ```
+
+- Upgrade after changing local values:
+  ```shell
+  helm upgrade --install penpot ./charts/penpot -n penpot -f local.penpot.values.yaml
+  ```
+
+- Check Gateway resources:
+  ```shell
+  kubectl get gateway,httproute -n penpot
+  ```
+
+- Expose the Envoy Gateway service locally:
+  ```shell
+  ./scripts/forward_gateway.sh
+  ```
+
+- Access the application at [http://penpot.example.com:8888/](http://penpot.example.com:8888/)
+
 > [!NOTE]
 > Add the following entry to `/etc/hosts`:
 >
@@ -52,7 +118,7 @@ pre-commit install --install-hooks -f
 > ```
 
 > [!TIP]
-> If you disable ingress, you can expose the app on port 8888 with:
+> If you disable ingress and gateway, you can expose the app on port 8888 with:
 >
 > ```shell
 > kubectl port-forward service/penpot 8888:8080 -n penpot
@@ -96,6 +162,8 @@ If needed, you can re-apply local dependencies manually:
 
 ### Troubleshooting
 
+#### Ingress
+
 If ingress-nginx admission webhook is not ready yet, you may see an error like:
 
 ```text
@@ -113,4 +181,33 @@ Check dependency resources with:
 
 ```shell
 kubectl get pods,svc,pvc -n penpot
+```
+
+#### Gateway API
+
+If you are using `EXPOSURE_MODE=gateway`, verify that Envoy Gateway is ready:
+
+```shell
+kubectl get pods -n envoy-gateway-system
+kubectl rollout status deployment/envoy-gateway -n envoy-gateway-system
+```
+
+Then verify the Gateway API resources:
+
+```shell
+kubectl get gatewayclass
+kubectl get gateway,httproute -n penpot
+kubectl get svc -n envoy-gateway-system
+```
+
+Check dependency resources with:
+
+```shell
+kubectl get pods,svc,pvc -n penpot
+```
+
+Expose the Envoy Gateway service locally:
+
+```shell
+./scripts/forward_gateway.sh
 ```

--- a/devel/penpot-gateway.yaml
+++ b/devel/penpot-gateway.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: penpot
+  namespace: penpot
+spec:
+  gatewayClassName: envoy
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "penpot.example.com"

--- a/devel/penpot.values.yaml
+++ b/devel/penpot.values.yaml
@@ -1,9 +1,4 @@
 ---
-## Default values for Penpot (local setup for development purpose)
-global:
-  postgresqlEnabled: true
-  redisEnabled: true
-
 config:
   publicUri: "http://penpot.example.com"
   apiSecretKey: "my-secret-key"
@@ -40,7 +35,29 @@ persistence:
 #  exporter:
 #    enabled: true
 
+
+## Test with ingress
+# Enable this block for Ingress-based local access
 ingress:
   enabled: true
   hosts:
     - "penpot.example.com"
+gateway:
+  enabled: false
+
+## Test with gateway
+# Enable this block for Gateway API-based local access
+# When gateway.enabled=true, set ingress.enabled=false unless you explicitly want both.
+# If you use scripts/forward_gateway.sh, set config.publicUri to http://penpot.example.com:8888.
+#ingress:
+#  enabled: false
+#gateway:
+#  enabled: true
+#  parentRefs:
+#    - name: penpot
+#      namespace: penpot
+#      sectionName: http
+#  hostnames:
+#    - "penpot.example.com"
+#  path: /
+#  pathMatchType: PathPrefix

--- a/scripts/create_cluster.sh
+++ b/scripts/create_cluster.sh
@@ -6,6 +6,7 @@ NAMESPACE="${NAMESPACE:-penpot}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 KUBECTL_CONTEXT="kind-${CLUSTER_NAME}"
 INGRESS_MANIFEST_URL="${INGRESS_MANIFEST_URL:-https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml}"
+EXPOSURE_MODE="${EXPOSURE_MODE:-ingress}"
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -31,14 +32,22 @@ kubectl config set-context "${NAMESPACE}" \
 
 kubectl config use-context "${NAMESPACE}"
 
-echo "Installing ingress-nginx for kind..."
-kubectl apply --context "${KUBECTL_CONTEXT}" -f "${INGRESS_MANIFEST_URL}"
+if [[ "${EXPOSURE_MODE}" == "ingress" ]]; then
+  echo "Installing ingress-nginx for kind..."
+  kubectl apply --context "${KUBECTL_CONTEXT}" -f "${INGRESS_MANIFEST_URL}"
 
-echo "Waiting for ingress-nginx controller..."
-kubectl rollout status deployment/ingress-nginx-controller \
-  -n ingress-nginx \
-  --context "${KUBECTL_CONTEXT}" \
-  --timeout=180s
+  echo "Waiting for ingress-nginx controller..."
+  kubectl rollout status deployment/ingress-nginx-controller \
+    -n ingress-nginx \
+    --context "${KUBECTL_CONTEXT}" \
+    --timeout=180s
+elif [[ "${EXPOSURE_MODE}" == "gateway" ]]; then
+  echo "Installing Gateway API stack for kind..."
+  KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" "${ROOT_DIR}/scripts/setup_gateway.sh"
+else
+  echo "Error: unsupported EXPOSURE_MODE=${EXPOSURE_MODE}. Use 'ingress' or 'gateway'." >&2
+  exit 1
+fi
 
 echo "Setting up local PostgreSQL and Valkey dependencies..."
 NAMESPACE="${NAMESPACE}" KUBECTL_CONTEXT="${KUBECTL_CONTEXT}" "${ROOT_DIR}/scripts/setup_dependencies.sh"
@@ -48,3 +57,4 @@ echo "Cluster is ready."
 echo "- kind cluster: ${CLUSTER_NAME}"
 echo "- kubectl context alias: ${NAMESPACE}"
 echo "- namespace: ${NAMESPACE}"
+echo "- exposure mode: ${EXPOSURE_MODE}"

--- a/scripts/forward_gateway.sh
+++ b/scripts/forward_gateway.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-penpot-cluster}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${CLUSTER_NAME}}"
+GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-penpot}"
+GATEWAY_NAME="${GATEWAY_NAME:-penpot}"
+ENVOY_NAMESPACE="${ENVOY_NAMESPACE:-envoy-gateway-system}"
+LOCAL_PORT="${LOCAL_PORT:-8888}"
+REMOTE_PORT="${REMOTE_PORT:-80}"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+require_command kubectl
+
+echo "Finding Envoy service for Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME}..."
+ENVOY_SERVICE="$(
+  kubectl get svc \
+    -n "${ENVOY_NAMESPACE}" \
+    --context "${KUBECTL_CONTEXT}" \
+    --selector="gateway.envoyproxy.io/owning-gateway-namespace=${GATEWAY_NAMESPACE},gateway.envoyproxy.io/owning-gateway-name=${GATEWAY_NAME}" \
+    -o jsonpath='{.items[0].metadata.name}'
+)"
+
+if [[ -z "${ENVOY_SERVICE}" ]]; then
+  echo "Error: Envoy service not found for Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME}." >&2
+  echo "Check Gateway status with: kubectl get gateway,httproute -n ${GATEWAY_NAMESPACE}" >&2
+  exit 1
+fi
+
+echo "Forwarding http://penpot.example.com:${LOCAL_PORT}/ to service/${ENVOY_SERVICE}:${REMOTE_PORT}"
+kubectl port-forward \
+  -n "${ENVOY_NAMESPACE}" \
+  --context "${KUBECTL_CONTEXT}" \
+  "service/${ENVOY_SERVICE}" \
+  "${LOCAL_PORT}:${REMOTE_PORT}"

--- a/scripts/setup_gateway.sh
+++ b/scripts/setup_gateway.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-penpot-cluster}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${CLUSTER_NAME}}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-1.5.1}"
+ENVOY_GATEWAY_CHART_VERSION="${ENVOY_GATEWAY_CHART_VERSION:-1.8.1}"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+require_command kubectl
+require_command helm
+
+echo "Installing Gateway API CRDs..."
+kubectl apply --server-side --context "${KUBECTL_CONTEXT}" \
+  -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v${GATEWAY_API_VERSION}/standard-install.yaml"
+
+echo "Installing Envoy Gateway via Helm OCI chart..."
+helm upgrade --install eg oci://docker.io/envoyproxy/gateway-helm \
+  --kube-context "${KUBECTL_CONTEXT}" \
+  --namespace envoy-gateway-system \
+  --create-namespace \
+  --version "${ENVOY_GATEWAY_CHART_VERSION}" \
+  --skip-crds
+
+echo "Waiting for Envoy Gateway controller..."
+kubectl rollout status deployment/envoy-gateway \
+  -n envoy-gateway-system \
+  --context "${KUBECTL_CONTEXT}" \
+  --timeout=300s
+
+echo "Creating local GatewayClass and Gateway..."
+kubectl apply --context "${KUBECTL_CONTEXT}" \
+  -f "${ROOT_DIR}/devel/penpot-gateway.yaml"
+
+echo ""
+echo "Gateway API stack is ready."
+echo "After installing Penpot with gateway.enabled=true, expose Envoy locally with:"
+echo "  ${ROOT_DIR}/scripts/forward_gateway.sh"


### PR DESCRIPTION
![](https://i.imgur.com/TIzzfHB.gif)

  - Add an optional `HTTPRoute` template controlled by `gateway.enabled`.
  - Add Gateway API values for `parentRefs`, `hostnames`, path matching, labels, and annotations.
  - Document Gateway API values in the chart README.
  - Extend the local kind development setup with an `EXPOSURE_MODE` selector:
    - `ingress` remains the default.
    - `gateway` installs Gateway API CRDs, Envoy Gateway, `GatewayClass`, and a local `Gateway`.
  - Add local development docs for testing Penpot through Gateway API.
  - Add `scripts/forward_gateway.sh` to expose the Envoy Gateway service locally on port `8888`.