### PR TITLE
fix(mcp): align mcp hpa maxReplicas with the other components

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -39,3 +39,5 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: changed
+      description: Default mcp.autoscaling.hpa.maxReplicas raised to 5, matching the other components

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -419,9 +419,9 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | mcp.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
-| mcp.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":1,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the MCP server pods. |
+| mcp.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the MCP server pods. |
 | mcp.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the MCP server. |
-| mcp.autoscaling.hpa.maxReplicas | int | `1` | Maximum number of MCP server replicas. |
+| mcp.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of MCP server replicas. |
 | mcp.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
 | mcp.autoscaling.hpa.minReplicas | int | `1` | Minimum number of MCP server replicas. |
 | mcp.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the MCP server. Requires VPA operator installed in the cluster. |

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -845,7 +845,7 @@ mcp:
       minReplicas: 1
       # -- Maximum number of MCP server replicas.
       # @section -- MCP parameters
-      maxReplicas: 1
+      maxReplicas: 5
       # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
       # @section -- MCP parameters
       metrics:


### PR DESCRIPTION
`mcp.autoscaling.hpa.maxReplicas` defaulted to `1` while every other component defaults to `5`. That came from the upstream documentation stating the MCP server requires a single Penpot instance, which no longer holds — MCP scales like any other component now.

Only a default changes. Anyone who set the value explicitly is unaffected.