### PR TITLE
feat(penpot): accept image.pullPolicy on exporter and mcp

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -41,3 +41,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: Default mcp.autoscaling.hpa.maxReplicas raised to 5, matching the other components
+    - kind: added
+      description: Accept image.pullPolicy on the exporter and mcp components, aligning them with the backend and frontend
+    - kind: deprecated
+      description: image.imagePullPolicy on the exporter and mcp components, superseded by image.pullPolicy

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -391,7 +391,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | exporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | exporter.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | exporter.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
-| exporter.image.imagePullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
+| exporter.image.imagePullPolicy | string | `"IfNotPresent"` | Deprecated, use `pullPolicy` instead. The image pull policy to use. Kept for backwards compatibility: this component historically used a different key name than the backend and frontend. If `pullPolicy` is set it takes precedence, and this key will be removed in a future major version. |
 | exporter.image.repository | string | `"penpotapp/exporter"` | The Docker repository to pull the image from. |
 | exporter.image.tag | string | `"2.17.1"` | The image tag to use. |
 | exporter.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
@@ -430,7 +430,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | mcp.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | mcp.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
 | mcp.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to the MCP server container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
-| mcp.image.imagePullPolicy | string | `"IfNotPresent"` | The image pull policy to use. |
+| mcp.image.imagePullPolicy | string | `"IfNotPresent"` | Deprecated, use `pullPolicy` instead. The image pull policy to use. Kept for backwards compatibility: this component historically used a different key name than the backend and frontend. If `pullPolicy` is set it takes precedence, and this key will be removed in a future major version. |
 | mcp.image.repository | string | `"penpotapp/mcp"` | The Docker repository to pull the image from. |
 | mcp.image.tag | string | `"2.17.1"` | The image tag to use. |
 | mcp.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |

--- a/charts/penpot/templates/exporter-deployment.yml
+++ b/charts/penpot/templates/exporter-deployment.yml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-exporter
           image: "{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
-          imagePullPolicy: {{ .Values.exporter.image.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.exporter.image.pullPolicy | default .Values.exporter.image.imagePullPolicy }}
           {{- with (include "penpot.containerSecurityContext" (dict "ctx" . "values" .Values.exporter.containerSecurityContext)) }}
           securityContext:
             {{- . | nindent 12 }}

--- a/charts/penpot/templates/mcp-deployment.yml
+++ b/charts/penpot/templates/mcp-deployment.yml
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-mcp
           image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag }}"
-          imagePullPolicy: {{ .Values.mcp.image.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy | default .Values.mcp.image.imagePullPolicy }}
           {{- with (include "penpot.containerSecurityContext" (dict "ctx" . "values" .Values.mcp.containerSecurityContext)) }}
           securityContext:
             {{- . | nindent 12 }}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -628,7 +628,7 @@ exporter:
     # -- The image tag to use.
     # @section -- Exporter parameters
     tag: 2.17.1
-    # -- The image pull policy to use.
+    # -- Deprecated, use `pullPolicy` instead. The image pull policy to use. Kept for backwards compatibility: this component historically used a different key name than the backend and frontend. If `pullPolicy` is set it takes precedence, and this key will be removed in a future major version.
     # @section -- Exporter parameters
     imagePullPolicy: IfNotPresent
   # -- The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount.
@@ -757,7 +757,7 @@ mcp:
     # -- The image tag to use.
     # @section -- MCP parameters
     tag: 2.17.1
-    # -- The image pull policy to use.
+    # -- Deprecated, use `pullPolicy` instead. The image pull policy to use. Kept for backwards compatibility: this component historically used a different key name than the backend and frontend. If `pullPolicy` is set it takes precedence, and this key will be removed in a future major version.
     # @section -- MCP parameters
     imagePullPolicy: IfNotPresent
   # -- The number of replicas to deploy.


### PR DESCRIPTION
The four components disagree on how to name the same setting: backend and frontend read `image.pullPolicy`, exporter and mcp read `image.imagePullPolicy`. Setting the wrong one does nothing and says nothing.

Where it came from: in the initial commit `bc96a6b` the backend block was copy-pasted to frontend and exporter, the `@param` doc line was changed to `imagePullPolicy` in both copies but the actual key only in exporter. The frontend doc stayed wrong until `2001dfc` fixed the text rather than the key — the right call, since changing the key would have broken users. `0c3125d` then copied the exporter block for MCP, making it 2–2.

`pullPolicy` now works everywhere. `imagePullPolicy` keeps working on exporter and mcp and is marked deprecated; removing it belongs in a future major.

**Please do not add a default for `pullPolicy` in `values.yaml`.** It would always be non-empty, `default` would never fall through, and everyone setting `imagePullPolicy` today would silently get `IfNotPresent`.
 
Verify with `helm template`, with and without `pullPolicy`, on both components.