### PR TITLE
feat(penpot): add values.schema.json

### DIFF
--- a/.github/workflows/values-schema.yml
+++ b/.github/workflows/values-schema.yml
@@ -1,0 +1,198 @@
+---
+name: Values schema
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - charts/penpot/**
+      - scripts/*.py
+      - .github/workflows/values-schema.yml
+  pull_request:
+    paths:
+      - charts/penpot/**
+      - scripts/*.py
+      - .github/workflows/values-schema.yml
+  workflow_dispatch:
+
+jobs:
+  # The repository may grow more charts, so the list is discovered rather than
+  # written down. Every job below runs once per chart.
+  discover:
+    name: Find charts
+    runs-on: ubuntu-latest
+    outputs:
+      charts: ${{ steps.find.outputs.charts }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: find
+        run: |
+          charts=$(find charts -mindepth 1 -maxdepth 1 -type d \
+            -exec test -f '{}/Chart.yaml' ';' -print | sort | jq -R -s -c 'split("\n")[:-1]')
+          echo "charts=$charts" >> "$GITHUB_OUTPUT"
+          echo "found: $charts"
+
+  metaschema:
+    name: Schema is well formed (${{ matrix.chart }})
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.discover.outputs.charts) }}
+    env:
+      CHART: ${{ matrix.chart }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install check-jsonschema
+        run: pip install --disable-pip-version-check check-jsonschema
+
+      - name: Validate values.schema.json against the JSON Schema metaschema
+        run: check-jsonschema --check-metaschema "$CHART/values.schema.json"
+
+      - name: Validate the default values.yaml against the schema
+        run: check-jsonschema --schemafile "$CHART/values.schema.json" "$CHART/values.yaml"
+
+      # The schema accepts unknown top-level keys at runtime so that a user's
+      # values file never fails the install over a stray key. That leniency is
+      # for users, not for us: this fails if values.yaml grows a key the schema
+      # does not describe.
+      - name: Every values.yaml key must be described
+        run: |
+          pip install --disable-pip-version-check --quiet pyyaml
+          scripts/check-schema-coverage.py --chart "$CHART"
+
+      # values.yaml owns the descriptions (helm-docs renders them into README.md)
+      # and the schema copies them so editors show the same text on hover. This
+      # fails if the two drift apart.
+      - name: Descriptions must match values.yaml
+        run: |
+          pip install --disable-pip-version-check --quiet pyyaml
+          scripts/sync-descriptions.py --chart "$CHART" --check
+
+  fixtures:
+    name: Fixtures (${{ matrix.chart }}, helm ${{ matrix.helm }})
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.discover.outputs.charts) }}
+        # Oldest supported release plus the current one: Helm switched its JSON
+        # Schema library in 3.13, so both code paths are exercised.
+        helm: [v3.12.3, latest]
+    env:
+      CHART: ${{ matrix.chart }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: ${{ matrix.helm }}
+
+      - name: Default values must pass
+        run: helm lint "$CHART"
+
+      - name: Valid fixtures must pass lint and render
+        run: |
+          set -euo pipefail
+          for f in "$CHART"/tests/values/valid/*.yaml; do
+            echo "::group::$f"
+            helm lint "$CHART" --values "$f"
+            helm template schema-test "$CHART" --values "$f" >/dev/null
+            echo "::endgroup::"
+          done
+
+      # Helm validates values.schema.json before rendering templates, so a schema
+      # that rejected these keys would shadow the migration message in
+      # install-validation.yaml. That is why `global` is left open in the schema,
+      # and this asserts it stays that way.
+      - name: The 1.0.0 migration gate must still be what fires
+        run: |
+          set -uo pipefail
+          if out=$(helm template guard "$CHART" --set global.postgresqlEnabled=true 2>&1); then
+            echo "::error::expected install-validation.yaml to block this install"
+            exit 1
+          fi
+          if ! grep -q "no longer supports Bitnami" <<<"$out"; then
+            echo "::error::blocked, but not by the migration gate"
+            echo "$out"
+            exit 1
+          fi
+          echo "ok: the migration message is what the user sees"
+
+      # Same reasoning: httproute.yml already fails with a written explanation, so
+      # the schema stays quiet here rather than pre-empting it with a generic
+      # "[] should be non-empty".
+      - name: The gateway guard must still be what fires
+        run: |
+          set -uo pipefail
+          if out=$(helm template guard "$CHART" --set gateway.enabled=true 2>&1); then
+            echo "::error::expected httproute.yml to reject an empty parentRefs"
+            exit 1
+          fi
+          if ! grep -q "requires gateway.parentRefs" <<<"$out"; then
+            echo "::error::blocked, but not by the gateway guard"
+            echo "$out"
+            exit 1
+          fi
+          echo "ok: the gateway message is what the user sees"
+
+      - name: Invalid fixtures must be rejected by the schema
+        run: |
+          set -uo pipefail
+          failed=0
+          for f in "$CHART"/tests/values/invalid/*.yaml; do
+            if out=$(helm lint "$CHART" --values "$f" 2>&1); then
+              echo "::error file=$f::expected the schema to reject this file, but it passed"
+              failed=1
+            elif ! grep -q "meet the specifications" <<<"$out"; then
+              echo "::error file=$f::rejected, but not by the values schema"
+              echo "$out"
+              failed=1
+            else
+              echo "ok: $f rejected as expected"
+            fi
+          done
+          exit "$failed"
+
+  upstream:
+    name: Consistency with upstream (${{ matrix.chart }})
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.discover.outputs.charts) }}
+    env:
+      CHART: ${{ matrix.chart }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install --disable-pip-version-check pyyaml
+
+      - name: Component image tags must match appVersion
+        run: scripts/check-image-tags.py --chart "$CHART"
+
+      # The schema only checks the enable-/disable- syntax of config.flags.
+      # Penpot accepts unknown flag names without complaining, so a typo is
+      # silently a no-op. This compares against the list in the penpot repo,
+      # pinned to the appVersion this chart deploys.
+      #
+      # Warnings only, by design: flags come and go between versions, some real
+      # ones never reach the parser (enable-air-gapped-conf is read by the nginx
+      # entrypoint), and the appVersion may not be tagged yet. A mismatch is
+      # worth a note on the PR, not a red build. Add --strict to enforce it.
+      - name: Cross-check flags against upstream (advisory)
+        run: scripts/check-flags.py --chart "$CHART"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,17 @@ repos:
     hooks:
       - id: helmlint
 
+  - repo: local
+    hooks:
+      - id: sync-schema-descriptions
+        name: Sync values.schema.json descriptions from values.yaml
+        # values.yaml owns the prose: helm-docs renders it into README.md and
+        # this copies it into the schema, so it is written once.
+        entry: scripts/sync-descriptions.py
+        language: system
+        files: ^charts/[^/]+/values\.(yaml|schema\.json)$
+        pass_filenames: false
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:

--- a/charts/penpot/.helmignore
+++ b/charts/penpot/.helmignore
@@ -23,3 +23,7 @@
 .vscode/
 # Doc templates
 README.md.gotmpl
+# Schema fixtures: they belong to the chart but must not ship inside the package.
+# Anchored with a leading slash on purpose: a bare `tests/` would also match
+# templates/tests/, which holds the helm test hook and must be packaged.
+/tests/

--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -41,7 +41,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: values.schema.json, validating values on install and providing editor autocompletion
-    - kind: added
-      description: helm test hook that checks Penpot answers on /readyz through the frontend
-    - kind: added
-      description: Document the assets volume constraint that applies when scaling the backend or frontend, and warn about it on install

--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -39,3 +39,9 @@ annotations:
       url: https://penpot.app/dev-diaries.html
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: added
+      description: values.schema.json, validating values on install and providing editor autocompletion
+    - kind: added
+      description: helm test hook that checks Penpot answers on /readyz through the frontend
+    - kind: added
+      description: Document the assets volume constraint that applies when scaling the backend or frontend, and warn about it on install

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -107,6 +107,51 @@ config:
   flags: "enable-registration enable-login-with-password disable-email-verification enable-smtp"
 ```
 
+### Running more than one replica
+
+Every component can be scaled with `replicaCount`, or automatically through
+`autoscaling.hpa`. Before raising either, check how assets are stored.
+
+With the default `persistence.assets.enabled: true`, the chart creates one
+PersistentVolumeClaim with `accessModes: [ReadWriteOnce]`, and **both the backend
+and the frontend mount it**. A ReadWriteOnce volume can only be attached to a
+single node, so on a cluster with more than one node a second replica of either
+component may be scheduled elsewhere and stay `Pending` indefinitely, waiting for
+a volume it cannot get. The exporter and the MCP server do not mount it and scale
+freely.
+
+Pick one of these before scaling the backend or the frontend:
+
+- **Object storage (recommended).** Move assets out of the cluster entirely and
+  the constraint disappears:
+
+  ```yml
+  config:
+    objectsStorage:
+      storageBackend: s3
+      s3:
+        bucket: your-bucket
+        region: your-region
+  persistence:
+    assets:
+      enabled: false
+  ```
+
+- **A ReadWriteMany volume**, if your storage provisioner supports it (NFS,
+  CephFS, Azure Files, EFS, …):
+
+  ```yml
+  persistence:
+    assets:
+      accessModes:
+        - ReadWriteMany
+      storageClass: your-rwx-storage-class
+  ```
+
+Scaling with the default ReadWriteOnce volume can appear to work on a
+single-node cluster, where every replica lands on the same node. It stops working
+as soon as a second node exists.
+
 ### 🔐 OpenShift Requirements
 
 Penpot workloads use fixed `runAsUser` and `fsGroup` values by default. OpenShift `restricted-v2` rejects those IDs unless they belong to the namespace-assigned range.
@@ -181,7 +226,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.compatibility.openshift.adaptSecurityContext | string | `"auto"` |  |
+| global.compatibility.openshift.adaptSecurityContext | string | `"auto"` | Adapt Penpot workload securityContext sections to OpenShift restricted-v2 SCC by omitting runAsUser, runAsGroup and fsGroup and letting the platform assign allowed IDs. Possible values: auto (apply when an OpenShift Route API is detected), force (perform the adaptation always), disabled (do not perform adaptation) |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names. E.g. imagePullSecrets:   - myRegistryKeySecretName |
 
 ### General
@@ -204,7 +249,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | config.existingSecret | string | `""` | The name of an existing secret. |
 | config.extraEnvs | list | `[]` | Specify any additional environment values you want to provide to all the containers (frontend, backend and exporter) in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) |
 | config.fileDataBackend | string | `"legacy-db"` | Define the strategy (backend) for internal file data storage of Penpot. Use "legacy-db" (default) the current behaviour, "db" to use an specific table in the database (future default) and "storage" to use the predefined objects storage system (S3, file system,...) |
-| config.flags | string | `"enable-registration enable-login-with-password disable-email-verification enable-smtp enable-mcp"` | The feature flags to enable. Check [the official docs](https://help.penpot.app/technical-guide/configuration/) for more info. |
+| config.flags | string | `"enable-registration enable-login-with-password disable-email-verification enable-smtp enable-mcp"` | The feature flags to enable. Every entry must be prefixed with `enable-` or `disable-`: any other token is silently ignored, and unknown flag names are accepted without complaint, so a typo is a no-op rather than an error. The available flags change between Penpot versions, check [the official docs](https://help.penpot.app/technical-guide/configuration/) for the list matching your appVersion. |
 | config.httpServerMaxBodySize | string | `"367001600"` | Defines the maximum size of HTTP request bodies (in bytes) that penpot will accept from clients. It controls how large files or data payloads can be when uploading files, submitting forms, or making API requests. It also helps protect against denial-of-service attacks by rejecting oversized requests. Default value for Penpot is 367001600 bytes (~350 MB). See [Nginx documentation]( https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). |
 | config.internalResolver | string | `""` | Add custom resolver for frontend. e.g. 192.168.1.1 |
 | config.objectsStorage.filesystem.directory | string | `"/opt/data/assets"` | The storage directory to use if you chose the filesystem storage backend. |
@@ -302,12 +347,12 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 |-----|------|---------|-------------|
 | backend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | backend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the backend pods. |
-| backend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the backend. When enabled, replicaCount is ignored. |
-| backend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of backend replicas. |
+| backend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored. |
+| backend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of replicas. |
 | backend.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
-| backend.autoscaling.hpa.minReplicas | int | `1` | Minimum number of backend replicas. |
-| backend.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the backend. Requires VPA operator installed in the cluster. |
-| backend.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the backend containers. |
+| backend.autoscaling.hpa.minReplicas | int | `1` | Minimum number of replicas. |
+| backend.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster. |
+| backend.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the containers. |
 | backend.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | backend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | backend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
@@ -317,7 +362,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | backend.image.tag | string | `"2.17.2"` | The image tag to use. |
 | backend.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | backend.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
-| backend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the backend pods. |
+| backend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the pods. |
 | backend.pdb.maxUnavailable | int,string | `nil` | The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%"). |
 | backend.pdb.minAvailable | int,string | `nil` | The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%"). |
 | backend.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
@@ -325,14 +370,14 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | backend.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | backend.replicaCount | int | `1` | The number of replicas to deploy. |
 | backend.resources | object | `{"limits":{},"requests":{}}` | Penpot backend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| backend.resources.limits | object | `{}` | The resources limits for the Penpot backend containers |
-| backend.resources.requests | object | `{}` | The requested resources for the Penpot backend containers |
-| backend.service.annotations | object | `{}` | Mapped annotations for the backend service |
-| backend.service.port | int | `6060` | The http service port to use. |
-| backend.service.type | string | `"ClusterIP"` | The http service type to create. |
+| backend.resources.limits | object | `{}` | The resources limits for the Penpot containers. |
+| backend.resources.requests | object | `{}` | The requested resources for the Penpot containers. |
+| backend.service.annotations | object | `{}` | Mapped annotations for the service. |
+| backend.service.port | int | `6060` | The service port to use. |
+| backend.service.type | string | `"ClusterIP"` | The service type to create. |
 | backend.startupProbe | object | `{"failureThreshold":30,"httpGet":{"path":"/readyz","port":"http"},"periodSeconds":10}` | Startup probe for the Penpot backend containers. Tolerates up to 30 * 10 = 300 seconds = 5 Minutes. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) |
 | backend.tolerations | list | `[]` | Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
-| backend.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| backend.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) E.g. updateStrategy:   type: RollingUpdate   rollingUpdate:     maxSurge: 25%     maxUnavailable: 25% |
 | backend.volumeMounts | list | `[]` | Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | backend.volumes | list | `[]` | Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 
@@ -342,12 +387,12 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 |-----|------|---------|-------------|
 | frontend.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | frontend.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the frontend pods. |
-| frontend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the frontend. When enabled, replicaCount is ignored. |
-| frontend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of frontend replicas. |
+| frontend.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored. |
+| frontend.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of replicas. |
 | frontend.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
-| frontend.autoscaling.hpa.minReplicas | int | `1` | Minimum number of frontend replicas. |
-| frontend.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the frontend. Requires VPA operator installed in the cluster. |
-| frontend.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the frontend containers. |
+| frontend.autoscaling.hpa.minReplicas | int | `1` | Minimum number of replicas. |
+| frontend.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster. |
+| frontend.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the containers. |
 | frontend.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | frontend.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
@@ -357,7 +402,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | frontend.image.tag | string | `"2.17.2"` | The image tag to use. |
 | frontend.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | frontend.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the frontend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
-| frontend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the frontend pods. |
+| frontend.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the pods. |
 | frontend.pdb.maxUnavailable | int,string | `nil` | The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%"). |
 | frontend.pdb.minAvailable | int,string | `nil` | The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%"). |
 | frontend.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
@@ -365,13 +410,13 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | frontend.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | frontend.replicaCount | int | `1` | The number of replicas to deploy. |
 | frontend.resources | object | `{"limits":{},"requests":{}}` | Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| frontend.resources.limits | object | `{}` | The resources limits for the Penpot frontend containers |
-| frontend.resources.requests | object | `{}` | The requested resources for the Penpot frontend containers |
-| frontend.service.annotations | object | `{}` | Mapped annotations for the frontend service |
+| frontend.resources.limits | object | `{}` | The resources limits for the Penpot containers. |
+| frontend.resources.requests | object | `{}` | The requested resources for the Penpot containers. |
+| frontend.service.annotations | object | `{}` | Mapped annotations for the service. |
 | frontend.service.port | int | `8080` | The service port to use. |
 | frontend.service.type | string | `"ClusterIP"` | The service type to create. |
 | frontend.tolerations | list | `[]` | Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
-| frontend.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| frontend.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) E.g. updateStrategy:   type: RollingUpdate   rollingUpdate:     maxSurge: 25%     maxUnavailable: 25% |
 | frontend.volumeMounts | list | `[]` | Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | frontend.volumes | list | `[]` | Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 
@@ -381,12 +426,12 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 |-----|------|---------|-------------|
 | exporter.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | exporter.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the exporter pods. |
-| exporter.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the exporter. When enabled, replicaCount is ignored. |
-| exporter.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of exporter replicas. |
+| exporter.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored. |
+| exporter.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of replicas. |
 | exporter.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
-| exporter.autoscaling.hpa.minReplicas | int | `1` | Minimum number of exporter replicas. |
-| exporter.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the exporter. Requires VPA operator installed in the cluster. |
-| exporter.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the exporter containers. |
+| exporter.autoscaling.hpa.minReplicas | int | `1` | Minimum number of replicas. |
+| exporter.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster. |
+| exporter.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the containers. |
 | exporter.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | exporter.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | exporter.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
@@ -396,7 +441,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | exporter.image.tag | string | `"2.17.2"` | The image tag to use. |
 | exporter.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | exporter.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the exporter pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
-| exporter.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the exporter pods. |
+| exporter.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the pods. |
 | exporter.pdb.maxUnavailable | int,string | `nil` | The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%"). |
 | exporter.pdb.minAvailable | int,string | `nil` | The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%"). |
 | exporter.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
@@ -404,13 +449,13 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | exporter.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | exporter.replicaCount | int | `1` | The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount. |
 | exporter.resources | object | `{"limits":{},"requests":{}}` | Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| exporter.resources.limits | object | `{}` | The resources limits for the Penpot frontend containers |
-| exporter.resources.requests | object | `{}` | The requested resources for the Penpot frontend containers |
-| exporter.service.annotations | object | `{}` | Mapped annotations for the exporter service |
+| exporter.resources.limits | object | `{}` | The resources limits for the Penpot containers. |
+| exporter.resources.requests | object | `{}` | The requested resources for the Penpot containers. |
+| exporter.service.annotations | object | `{}` | Mapped annotations for the service. |
 | exporter.service.port | int | `6061` | The service port to use. |
 | exporter.service.type | string | `"ClusterIP"` | The service type to create. |
 | exporter.tolerations | list | `[]` | Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
-| exporter.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| exporter.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) E.g. updateStrategy:   type: RollingUpdate   rollingUpdate:     maxSurge: 25%     maxUnavailable: 25% |
 | exporter.volumeMounts | list | `[]` | Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | exporter.volumes | list | `[]` | Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 
@@ -420,12 +465,12 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 |-----|------|---------|-------------|
 | mcp.affinity | object | `{}` | Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity) |
 | mcp.autoscaling | object | `{"hpa":{"enabled":false,"maxReplicas":5,"metrics":[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}],"minReplicas":1},"vpa":{"enabled":false,"resourcePolicy":{},"updateMode":"Auto"}}` | Configure autoscaling for the MCP server pods. |
-| mcp.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler for the MCP server. |
-| mcp.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of MCP server replicas. |
+| mcp.autoscaling.hpa.enabled | bool | `false` | Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored. |
+| mcp.autoscaling.hpa.maxReplicas | int | `5` | Maximum number of replicas. |
 | mcp.autoscaling.hpa.metrics | list | `[{"resource":{"name":"cpu","target":{"averageUtilization":70,"type":"Utilization"}},"type":"Resource"},{"resource":{"name":"memory","target":{"averageUtilization":80,"type":"Utilization"}},"type":"Resource"}]` | Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) |
-| mcp.autoscaling.hpa.minReplicas | int | `1` | Minimum number of MCP server replicas. |
-| mcp.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler for the MCP server. Requires VPA operator installed in the cluster. |
-| mcp.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the MCP server containers. |
+| mcp.autoscaling.hpa.minReplicas | int | `1` | Minimum number of replicas. |
+| mcp.autoscaling.vpa.enabled | bool | `false` | Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster. |
+| mcp.autoscaling.vpa.resourcePolicy | object | `{}` | VPA resource policy for the containers. |
 | mcp.autoscaling.vpa.updateMode | string | `"Auto"` | VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) |
 | mcp.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["all"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | mcp.deploymentAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Deployment |
@@ -435,7 +480,7 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | mcp.image.tag | string | `"2.17.2"` | The image tag to use. |
 | mcp.nodeSelector | object | `{}` | Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/) |
 | mcp.pdb | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":null}` | Configure Pod Disruption Budget for the MCP server pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
-| mcp.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the MCP server pods. |
+| mcp.pdb.enabled | bool | `false` | Enable Pod Disruption Budget for the pods. |
 | mcp.pdb.maxUnavailable | int,string | `nil` | The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%"). |
 | mcp.pdb.minAvailable | int,string | `nil` | The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%"). |
 | mcp.podAnnotations | object | `{}` | An optional map of annotations to be applied to the controller Pods |
@@ -443,14 +488,14 @@ This allows running the chart securely in OpenShift without granting anyuid perm
 | mcp.podSecurityContext | object | `{"fsGroup":1001}` | Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
 | mcp.replicaCount | int | `1` | The number of replicas to deploy. |
 | mcp.resources | object | `{"limits":{},"requests":{}}` | Penpot MCP server resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/) |
-| mcp.resources.limits | object | `{}` | The resources limits for the Penpot MCP server containers |
-| mcp.resources.requests | object | `{}` | The requested resources for the Penpot MCP server containers |
-| mcp.service.annotations | object | `{}` | Mapped annotations for the MCP service. |
+| mcp.resources.limits | object | `{}` | The resources limits for the Penpot containers. |
+| mcp.resources.requests | object | `{}` | The requested resources for the Penpot containers. |
+| mcp.service.annotations | object | `{}` | Mapped annotations for the service. |
 | mcp.service.httpPort | int | `4401` | The HTTP/SSE port for AI clients (e.g. Claude). |
 | mcp.service.type | string | `"ClusterIP"` | The service type to create. |
 | mcp.service.wsPort | int | `4402` | The WebSocket port for the Penpot MCP plugin. |
 | mcp.tolerations | list | `[]` | Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) |
-| mcp.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) |
+| mcp.updateStrategy | object | `{"type":"RollingUpdate"}` | The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) E.g. updateStrategy:   type: RollingUpdate   rollingUpdate:     maxSurge: 25%     maxUnavailable: 25% |
 | mcp.volumeMounts | list | `[]` | Extra volumes to be mounted in the container. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 | mcp.volumes | list | `[]` | Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/) |
 

--- a/charts/penpot/README.md.gotmpl
+++ b/charts/penpot/README.md.gotmpl
@@ -106,6 +106,51 @@ config:
   flags: "enable-registration enable-login-with-password disable-email-verification enable-smtp"
 ```
 
+### Running more than one replica
+
+Every component can be scaled with `replicaCount`, or automatically through
+`autoscaling.hpa`. Before raising either, check how assets are stored.
+
+With the default `persistence.assets.enabled: true`, the chart creates one
+PersistentVolumeClaim with `accessModes: [ReadWriteOnce]`, and **both the backend
+and the frontend mount it**. A ReadWriteOnce volume can only be attached to a
+single node, so on a cluster with more than one node a second replica of either
+component may be scheduled elsewhere and stay `Pending` indefinitely, waiting for
+a volume it cannot get. The exporter and the MCP server do not mount it and scale
+freely.
+
+Pick one of these before scaling the backend or the frontend:
+
+- **Object storage (recommended).** Move assets out of the cluster entirely and
+  the constraint disappears:
+
+  ```yml
+  config:
+    objectsStorage:
+      storageBackend: s3
+      s3:
+        bucket: your-bucket
+        region: your-region
+  persistence:
+    assets:
+      enabled: false
+  ```
+
+- **A ReadWriteMany volume**, if your storage provisioner supports it (NFS,
+  CephFS, Azure Files, EFS, …):
+
+  ```yml
+  persistence:
+    assets:
+      accessModes:
+        - ReadWriteMany
+      storageClass: your-rwx-storage-class
+  ```
+
+Scaling with the default ReadWriteOnce volume can appear to work on a
+single-node cluster, where every replica lands on the same node. It stops working
+as soon as a second node exists.
+
 ### 🔐 OpenShift Requirements
 
 Penpot workloads use fixed `runAsUser` and `fsGroup` values by default. OpenShift `restricted-v2` rejects those IDs unless they belong to the namespace-assigned range.

--- a/charts/penpot/tests/README.md
+++ b/charts/penpot/tests/README.md
@@ -1,0 +1,168 @@
+# Chart test fixtures
+
+Values files used by `.github/workflows/values-schema.yml` to check that
+`values.schema.json` accepts what it should and rejects what it shouldn't.
+
+They live under the chart because they describe this chart, and `.helmignore`
+keeps them out of the published package. The pattern there is `/tests/`, anchored
+on purpose: a bare `tests/` would also match `templates/tests/`, which holds the
+helm test hook and has to ship.
+
+The scripts that consume them live in the repository's `scripts/` directory,
+alongside the existing shell tooling. `check-*` verify and are run by CI;
+`sync-*` writes and is run by pre-commit.
+
+Those scripts are not tied to this chart. With no `--chart` they act on every
+directory under `charts/` that holds a `Chart.yaml`, skipping the ones with
+nothing to check — no `values.schema.json`, no `config.flags` — and the workflow
+builds its matrix the same way. A second chart added to this repository is
+covered without touching either.
+
+- `valid/` — realistic overrides that **must** pass `helm lint` and `helm template`.
+- `invalid/` — overrides that **must** be rejected by the schema. The workflow
+  also asserts the failure comes from schema validation and not from a template
+  error, so a broken template can't make these pass by accident.
+
+Each file is merged on top of the chart defaults, so fixtures only contain the
+keys under test.
+
+## Adding a case
+
+Drop a new `.yaml` file into `valid/` or `invalid/` with a comment on the first
+line explaining what it covers. Nothing else to wire up; the workflow globs both
+directories.
+
+The numeric prefixes only give the files a stable reading order, roughly from
+general to specific. They are not identifiers and nothing refers to them, so
+renumber freely when adding or removing a case rather than leaving a gap.
+
+## Running it locally
+
+```sh
+helm lint charts/penpot
+for f in charts/penpot/tests/values/valid/*.yaml; do
+  helm lint charts/penpot --values "$f"
+done
+for f in charts/penpot/tests/values/invalid/*.yaml; do
+  helm lint charts/penpot --values "$f" && echo "UNEXPECTED PASS: $f"
+done
+```
+
+## Descriptions
+
+`values.yaml` is the single source of truth for descriptions: helm-docs renders
+them into `README.md`, and `scripts/sync-descriptions.py` copies them into
+`values.schema.json` so editors show the same text on hover. Write the prose once,
+in the `# --` comment.
+
+```sh
+scripts/sync-descriptions.py --chart charts/penpot            # write
+scripts/sync-descriptions.py --chart charts/penpot --check    # CI mode
+```
+
+Add it to `.pre-commit-config.yaml` after the helm-docs hook, so both run off the
+same edit:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: sync-schema-descriptions
+        name: Sync values.schema.json descriptions
+        entry: scripts/sync-descriptions.py --chart charts/penpot
+        language: system
+        files: ^charts/penpot/values\.(yaml|schema\.json)$
+        pass_filenames: false
+```
+
+A property that is a bare `$ref` gets wrapped in `allOf` so it can carry its own
+description without touching the shared constraints.
+
+Descriptions of the same key across components are worded identically on purpose
+("Maximum number of replicas." rather than "…of backend replicas."). The README
+table already shows the full key path in its own column, so naming the component
+in the prose is redundant, and identical wording lets the four components share
+one node in the schema. Keep it that way when adding keys: the script reports any
+group that disagrees instead of letting one component overwrite the others.
+
+## Upstream consistency
+
+`scripts/` holds three checks that the schema alone cannot cover:
+
+- `check-image-tags.py` — the backend, frontend, exporter and mcp image tags
+  must all equal `Chart.yaml`'s `appVersion`.
+- `check-flags.py` — cross-checks `config.flags` against the real flag list in
+  `common/src/app/common/flags.cljc`, pinned to the tag matching `appVersion`.
+  The schema can only enforce the `enable-`/`disable-` prefix, because Penpot's
+  parser accepts any name and silently ignores the ones it doesn't know, so a
+  typo becomes a no-op instead of an error.
+
+  **Unknown names are warnings, not failures.** Flags change between Penpot
+  versions, the appVersion may not be tagged yet, and some legitimate flags
+  never reach that parser at all — `enable-air-gapped-conf` is documented but
+  lives in the frontend image's nginx entrypoint, so it is allowlisted in the
+  script. A missing enable-/disable- prefix *is* fatal: that one does not depend
+  on the version. Use `--strict` if you want unknown names to fail too.
+
+Both run offline-friendly:
+
+```sh
+scripts/check-image-tags.py --chart charts/penpot
+scripts/check-flags.py --chart charts/penpot            # fetches from GitHub
+scripts/check-flags.py --chart charts/penpot --flags-file ./flags.cljc
+```
+
+## Rules the templates already own
+
+Two guards live in the templates and fail with a written explanation. Helm
+validates `values.schema.json` *before* rendering, so a schema rule covering the
+same ground replaces those messages with a generic one. The schema deliberately
+stays quiet on both, and a workflow step asserts each message still fires:
+
+| Guard | Message |
+|---|---|
+| `install-validation.yaml` | the 1.0.0 Bitnami migration is blocked until the globals are gone |
+| `httproute.yml` | `gateway.enabled=true requires gateway.parentRefs to be set` |
+
+Neither case can live in `invalid/`: those fixtures must fail *for schema
+reasons*, and these fail at render time on purpose.
+
+## Why `global` is open
+
+`templates/install-validation.yaml` blocks the upgrade with a written explanation
+when `global.postgresqlEnabled`, `valkeyEnabled` or `redisEnabled` are still set,
+which is the 1.0.0 Bitnami migration gate.
+
+Helm validates `values.schema.json` *before* rendering templates. If the schema
+closed `global`, those values files would die on a generic schema error and the
+user would never see that message. So `global` stays open on purpose, and the
+workflow asserts the migration message is what actually fires.
+
+That case cannot live in `invalid/`: those fixtures must fail *for schema
+reasons*, and this one deliberately fails at render time instead. It is a
+separate step in the workflow.
+
+## How strict the schema is, and where
+
+Sections (`backend`, `config`, `ingress`, …) use `additionalProperties: false`,
+so a key that Helm would silently ignore is an error instead — that is what
+catches `backend.replicaCounts` or `exporter.image.pullPolicyy`.
+
+**The root is deliberately open.** The schema ships inside the released chart and
+runs on every user's `helm install`, so a stray top-level key must not break
+somebody's deployment: values files carried over from 0.x still carrying
+`postgresql:`, YAML anchors, and keys read by GitOps tooling all pass. See
+`valid/11-foreign-root-keys.yaml`.
+
+`global` is open too, for a different reason: a parent chart injects the globals
+of every other subchart into it (`global.storageClass`, `global.imageRegistry`).
+
+The drift guard that root strictness used to provide now lives in CI instead:
+`scripts/check-schema-coverage.py` fails if `values.yaml` grows any key the
+schema does not describe. Strict for maintainers, forgiving for users.
+
+## Note on schema drift
+
+Because the schema uses `"additionalProperties": false`, any new key added to
+`values.yaml` without a matching entry in `values.schema.json` makes the
+`helm lint charts/penpot` step fail. That is intentional: it keeps the schema
+from silently falling behind the chart.

--- a/charts/penpot/tests/values/invalid/01-unknown-nested-key.yaml
+++ b/charts/penpot/tests/values/invalid/01-unknown-nested-key.yaml
@@ -1,0 +1,3 @@
+# Typo inside a known section.
+backend:
+  replicaCounts: 3

--- a/charts/penpot/tests/values/invalid/02-wrong-type.yaml
+++ b/charts/penpot/tests/values/invalid/02-wrong-type.yaml
@@ -1,0 +1,3 @@
+# replicaCount must be an integer, not a string.
+frontend:
+  replicaCount: "3"

--- a/charts/penpot/tests/values/invalid/03-bad-enum.yaml
+++ b/charts/penpot/tests/values/invalid/03-bad-enum.yaml
@@ -1,0 +1,6 @@
+# pullPolicy and service type are case sensitive enums.
+backend:
+  image:
+    pullPolicy: always
+  service:
+    type: ClusterIp

--- a/charts/penpot/tests/values/invalid/04-bad-public-uri.yaml
+++ b/charts/penpot/tests/values/invalid/04-bad-public-uri.yaml
@@ -1,0 +1,3 @@
+# publicUri must include the http/https scheme.
+config:
+  publicUri: "design.example.com"

--- a/charts/penpot/tests/values/invalid/05-s3-without-bucket.yaml
+++ b/charts/penpot/tests/values/invalid/05-s3-without-bucket.yaml
@@ -1,0 +1,6 @@
+# storageBackend s3 requires a bucket name.
+config:
+  objectsStorage:
+    storageBackend: s3
+    s3:
+      region: eu-west-1

--- a/charts/penpot/tests/values/invalid/06-pdb-both-fields.yaml
+++ b/charts/penpot/tests/values/invalid/06-pdb-both-fields.yaml
@@ -1,0 +1,6 @@
+# minAvailable and maxUnavailable are mutually exclusive.
+backend:
+  pdb:
+    enabled: true
+    minAvailable: 1
+    maxUnavailable: 1

--- a/charts/penpot/tests/values/invalid/07-ingress-without-hosts.yaml
+++ b/charts/penpot/tests/values/invalid/07-ingress-without-hosts.yaml
@@ -1,0 +1,4 @@
+# An enabled ingress needs at least one host.
+ingress:
+  enabled: true
+  hosts: []

--- a/charts/penpot/tests/values/invalid/08-bad-storage-size.yaml
+++ b/charts/penpot/tests/values/invalid/08-bad-storage-size.yaml
@@ -1,0 +1,4 @@
+# Not a valid Kubernetes quantity.
+persistence:
+  assets:
+    size: "20 gigas"

--- a/charts/penpot/tests/values/invalid/09-bad-vpa-mode.yaml
+++ b/charts/penpot/tests/values/invalid/09-bad-vpa-mode.yaml
@@ -1,0 +1,6 @@
+# updateMode is one of Off, Initial, Recreate, Auto.
+mcp:
+  autoscaling:
+    vpa:
+      enabled: true
+      updateMode: auto

--- a/charts/penpot/tests/values/invalid/10-bad-annotation-type.yaml
+++ b/charts/penpot/tests/values/invalid/10-bad-annotation-type.yaml
@@ -1,0 +1,5 @@
+# Annotation values must be strings.
+frontend:
+  service:
+    annotations:
+      prometheus.io/port: 8080

--- a/charts/penpot/tests/values/invalid/11-env-without-name.yaml
+++ b/charts/penpot/tests/values/invalid/11-env-without-name.yaml
@@ -1,0 +1,4 @@
+# Every env var entry needs a name.
+backend:
+  extraEnvs:
+    - value: "something"

--- a/charts/penpot/tests/values/invalid/12-bad-openshift-mode.yaml
+++ b/charts/penpot/tests/values/invalid/12-bad-openshift-mode.yaml
@@ -1,0 +1,5 @@
+# adaptSecurityContext is one of auto, force, disabled.
+global:
+  compatibility:
+    openshift:
+      adaptSecurityContext: "yes"

--- a/charts/penpot/tests/values/invalid/13-bad-flag-syntax.yaml
+++ b/charts/penpot/tests/values/invalid/13-bad-flag-syntax.yaml
@@ -1,0 +1,3 @@
+# Flags must all carry the enable-/disable- prefix; Penpot ignores the rest.
+config:
+  flags: "enable-smtp mcp disable-onboarding"

--- a/charts/penpot/tests/values/invalid/14-legacy-key-on-backend.yaml
+++ b/charts/penpot/tests/values/invalid/14-legacy-key-on-backend.yaml
@@ -1,0 +1,5 @@
+# imagePullPolicy was never read by the backend or frontend templates, so it
+# must not be silently accepted there.
+backend:
+  image:
+    imagePullPolicy: Always

--- a/charts/penpot/tests/values/valid/01-minimal.yaml
+++ b/charts/penpot/tests/values/valid/01-minimal.yaml
@@ -1,0 +1,8 @@
+# Minimal production-ish override: everything else comes from the chart defaults.
+config:
+  publicUri: "https://design.example.com"
+  apiSecretKey: "aVeryLongRandomSecretKeyUsedOnlyForTestingPurposes0123456789"
+  postgresql:
+    host: "penpot-postgresql.penpot.svc.cluster.local"
+  redis:
+    host: "penpot-valkey-master.penpot.svc.cluster.local"

--- a/charts/penpot/tests/values/valid/02-s3-and-ingress.yaml
+++ b/charts/penpot/tests/values/valid/02-s3-and-ingress.yaml
@@ -1,0 +1,27 @@
+# S3 object storage behind an nginx ingress with TLS.
+config:
+  publicUri: "https://design.example.com"
+  objectsStorage:
+    storageBackend: s3
+    s3:
+      bucket: penpot-assets
+      region: eu-west-1
+      endpointURI: "https://minio.example.com"
+      existingSecret: penpot-s3
+      secretKeys:
+        accessKeyIDKey: access-key-id
+        secretAccessKey: secret-access-key
+persistence:
+  assets:
+    enabled: false
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - design.example.com
+  tls:
+    - secretName: design-example-com-tls
+      hosts:
+        - design.example.com

--- a/charts/penpot/tests/values/valid/03-openshift-route.yaml
+++ b/charts/penpot/tests/values/valid/03-openshift-route.yaml
@@ -1,0 +1,31 @@
+# OpenShift: securityContext IDs nulled out and a Route instead of an Ingress.
+global:
+  compatibility:
+    openshift:
+      adaptSecurityContext: force
+backend:
+  podSecurityContext:
+    fsGroup: null
+  containerSecurityContext:
+    runAsUser: null
+    runAsNonRoot: false
+frontend:
+  podSecurityContext:
+    fsGroup: null
+  containerSecurityContext:
+    runAsUser: null
+    runAsNonRoot: false
+exporter:
+  podSecurityContext:
+    fsGroup: null
+  containerSecurityContext:
+    runAsUser: null
+    runAsNonRoot: false
+route:
+  enabled: true
+  host: design.apps.example.com
+  path: null
+  tls:
+    terminationType: edge
+    terminationPolicy: Redirect
+  wildcardPolicy: None

--- a/charts/penpot/tests/values/valid/04-autoscaling-and-pdb.yaml
+++ b/charts/penpot/tests/values/valid/04-autoscaling-and-pdb.yaml
@@ -1,0 +1,32 @@
+# HPA, PDB and resource limits on every component.
+backend:
+  autoscaling:
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 8
+  pdb:
+    enabled: true
+    minAvailable: 1
+  resources:
+    limits:
+      cpu: "2"
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+frontend:
+  replicaCount: 3
+  pdb:
+    enabled: true
+    maxUnavailable: "25%"
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+exporter:
+  autoscaling:
+    vpa:
+      enabled: true
+      updateMode: "Off"

--- a/charts/penpot/tests/values/valid/05-gateway-api.yaml
+++ b/charts/penpot/tests/values/valid/05-gateway-api.yaml
@@ -1,0 +1,17 @@
+# Gateway API HTTPRoute attached to a shared gateway.
+gateway:
+  enabled: true
+  hostnames:
+    - design.example.com
+  parentRefs:
+    - name: shared-gateway
+      namespace: infra
+      sectionName: http
+  pathMatchType: PathPrefix
+  path: /
+  filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+          - name: X-Forwarded-Proto
+            value: https

--- a/charts/penpot/tests/values/valid/06-extras.yaml
+++ b/charts/penpot/tests/values/valid/06-extras.yaml
@@ -1,0 +1,42 @@
+# Extra env vars, volumes, SMTP, OIDC and image pull secrets.
+global:
+  imagePullSecrets:
+    - myRegistryKeySecretName
+config:
+  flags: "disable-registration enable-login-with-oidc enable-smtp"
+  smtp:
+    enabled: true
+    host: smtp.example.com
+    port: 587
+    tls: true
+    defaultFrom: "no-reply@example.com"
+    existingSecret: penpot-smtp
+    secretKeys:
+      usernameKey: username
+      passwordKey: password
+  providers:
+    oidc:
+      enabled: true
+      baseURI: "https://keycloak.example.com/realms/main"
+      clientID: penpot
+      roles: "designer developer"
+  autoFileSnapshot:
+    every: 10
+    timeout: 90m
+  extraEnvs:
+    - name: PENPOT_HTTP_SERVER_MAX_MULTIPART_BODY_SIZE
+      value: "367001600"
+backend:
+  volumes:
+    - name: custom-tmp
+      emptyDir: {}
+  volumeMounts:
+    - name: custom-tmp
+      mountPath: /tmp/custom
+      readOnly: false
+  extraEnvs:
+    - name: JAVA_OPTS
+      valueFrom:
+        configMapKeyRef:
+          name: penpot-tuning
+          key: java-opts

--- a/charts/penpot/tests/values/valid/07-flags.yaml
+++ b/charts/penpot/tests/values/valid/07-flags.yaml
@@ -1,0 +1,16 @@
+# A flag set exercising several documented features at once.
+config:
+  flags: >-
+    disable-registration
+    enable-login-with-oidc
+    enable-oidc-registration
+    enable-smtp
+    enable-webhooks
+    enable-access-tokens
+    enable-auto-file-snapshot
+    disable-dashboard-templates-section
+    enable-air-gapped-conf
+  providers:
+    oidc:
+      enabled: true
+      baseURI: "https://sso.example.com/realms/main"

--- a/charts/penpot/tests/values/valid/08-mcp-scaled.yaml
+++ b/charts/penpot/tests/values/valid/08-mcp-scaled.yaml
@@ -1,0 +1,11 @@
+# The MCP server scales like any other component.
+mcp:
+  replicaCount: 3
+  pdb:
+    enabled: true
+    minAvailable: 1
+  autoscaling:
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 6

--- a/charts/penpot/tests/values/valid/09-yaml-anchors.yaml
+++ b/charts/penpot/tests/values/valid/09-yaml-anchors.yaml
@@ -1,0 +1,17 @@
+# YAML anchors and keys consumed by external tooling live under the x- prefix,
+# which the schema accepts and the chart ignores.
+x-node-selector: &nodeSelector
+  kubernetes.io/os: linux
+
+x-tolerations: &tolerations
+  - key: workload
+    operator: Equal
+    value: penpot
+    effect: NoSchedule
+
+backend:
+  nodeSelector: *nodeSelector
+  tolerations: *tolerations
+frontend:
+  nodeSelector: *nodeSelector
+  tolerations: *tolerations

--- a/charts/penpot/tests/values/valid/10-pullpolicy-per-component.yaml
+++ b/charts/penpot/tests/values/valid/10-pullpolicy-per-component.yaml
@@ -1,0 +1,14 @@
+# pullPolicy now works on every component. exporter and mcp still accept the
+# deprecated imagePullPolicy for backwards compatibility.
+backend:
+  image:
+    pullPolicy: Always
+frontend:
+  image:
+    pullPolicy: Always
+exporter:
+  image:
+    pullPolicy: Always
+mcp:
+  image:
+    imagePullPolicy: Always

--- a/charts/penpot/tests/values/valid/11-foreign-root-keys.yaml
+++ b/charts/penpot/tests/values/valid/11-foreign-root-keys.yaml
@@ -1,0 +1,8 @@
+# Unknown top-level keys are accepted on purpose: values files carried over from
+# 0.x, YAML anchors and keys read by external tooling must not break the install.
+# Keys inside a known section are still validated (see invalid/02).
+postgresql:
+  auth:
+    database: penpot
+my-gitops-tool:
+  syncWave: "3"

--- a/charts/penpot/values.schema.json
+++ b/charts/penpot/values.schema.json
@@ -1,0 +1,2304 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Penpot Helm chart values",
+  "description": "Values accepted by the Penpot chart. Unknown top-level keys are accepted on purpose for now: values files carried over from 0.x, YAML anchors and keys consumed by external tooling would otherwise fail the install. Keys inside a known section are still validated.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global parameters shared by all the chart components.",
+      "additionalProperties": true,
+      "properties": {
+        "compatibility": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "openshift": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "adaptSecurityContext": {
+                  "description": "Adapt Penpot workload securityContext sections to OpenShift restricted-v2 SCC by omitting runAsUser, runAsGroup and fsGroup and letting the platform assign allowed IDs. Possible values: auto (apply when an OpenShift Route API is detected), force (perform the adaptation always), disabled (do not perform adaptation)",
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "force",
+                    "disabled"
+                  ],
+                  "default": "auto"
+                }
+              }
+            }
+          }
+        },
+        "imagePullSecrets": {
+          "description": "Global Docker registry secret names.\nE.g.\nimagePullSecrets:\n  - myRegistryKeySecretName",
+          "type": "array",
+          "default": [],
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "nameOverride": {
+      "description": "To partially override common.names.fullname",
+      "type": "string",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "description": "To fully override common.names.fullname",
+      "type": "string",
+      "default": ""
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Specifies whether a ServiceAccount should be created.",
+          "type": "boolean",
+          "default": true
+        },
+        "annotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Annotations for service account. Evaluated as a template."
+        },
+        "name": {
+          "description": "The name of the ServiceAccount to use. If not set and enabled is true, a name is generated using the fullname template.",
+          "type": "string",
+          "default": "penpot"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "publicUri"
+      ],
+      "properties": {
+        "publicUri": {
+          "description": "The public domain to serve Penpot on.\n**IMPORTANT:** Set `disable-secure-session-cookies` in the flags if you plan on serving it on a non HTTPS domain.",
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https?://",
+          "default": "http://penpot.example.com"
+        },
+        "flags": {
+          "description": "The feature flags to enable. Every entry must be prefixed with `enable-` or `disable-`: any other token is silently ignored, and unknown flag names are accepted without complaint, so a typo is a no-op rather than an error. The available flags change between Penpot versions, check [the official docs](https://help.penpot.app/technical-guide/configuration/) for the list matching your appVersion.",
+          "type": "string",
+          "pattern": "^\\s*$|^\\s*(enable|disable)-[a-z0-9]+(-[a-z0-9]+)*(\\s+(enable|disable)-[a-z0-9]+(-[a-z0-9]+)*)*\\s*$",
+          "default": "enable-registration enable-login-with-password disable-email-verification enable-smtp enable-mcp"
+        },
+        "apiSecretKey": {
+          "description": "A random secret key needed for persistent user sessions. Generate with `python3 -c \"import secrets; print(secrets.token_urlsafe(64))\"` for example.",
+          "type": "string"
+        },
+        "existingSecret": {
+          "description": "The name of an existing secret.",
+          "type": "string",
+          "default": ""
+        },
+        "secretKeys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "apiSecretKey": {
+              "type": "string",
+              "default": "",
+              "description": "The api secret key to use from an existing secret."
+            }
+          }
+        },
+        "registrationDomainWhitelist": {
+          "description": "Comma separated list of allowed domains to register. Empty to allow all domains.",
+          "type": "string",
+          "default": ""
+        },
+        "telemetryEnabled": {
+          "description": "Whether to enable sending of anonymous telemetry data.",
+          "type": "boolean",
+          "default": true
+        },
+        "internalResolver": {
+          "description": "Add custom resolver for frontend. e.g. 192.168.1.1",
+          "type": "string",
+          "default": ""
+        },
+        "termsOfServicesUri": {
+          "type": "string",
+          "default": "",
+          "description": "Url adress to Terms of Services (empty to hide the link)"
+        },
+        "privacyPolicyUri": {
+          "type": "string",
+          "default": "",
+          "description": "Url adress to Privacy Policy (empty to hide the link)"
+        },
+        "postgresql": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host": {
+              "description": "The PostgreSQL host to connect to.",
+              "type": "string"
+            },
+            "port": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/port"
+                }
+              ],
+              "description": "The PostgreSQL host port to use."
+            },
+            "username": {
+              "type": "string",
+              "description": "The database username to use."
+            },
+            "password": {
+              "type": "string",
+              "description": "The database password to use."
+            },
+            "database": {
+              "type": "string",
+              "description": "The PostgreSQL database to use."
+            },
+            "existingSecret": {
+              "type": "string",
+              "default": "",
+              "description": "The name of an existing secret."
+            },
+            "secretKeys": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "postgresqlUriKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The postgresql uri key to use from an existing secret. (postgresql://host:port/database)."
+                },
+                "usernameKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The username key to use from an existing secret."
+                },
+                "passwordKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The password key to use from an existing secret."
+                }
+              }
+            }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "host": {
+              "description": "The Valkey host to connect to.",
+              "type": "string"
+            },
+            "port": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/port"
+                }
+              ],
+              "description": "The Valkey host port to use."
+            },
+            "database": {
+              "description": "The Valkey database to connect to.",
+              "type": [
+                "string",
+                "integer"
+              ],
+              "default": "0"
+            },
+            "existingSecret": {
+              "type": "string",
+              "default": "",
+              "description": "The name of an existing secret."
+            },
+            "secretKeys": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "redisUriKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The redis uri key to use from an existing secret. (redis://:password@host:port/database)."
+                }
+              }
+            }
+          }
+        },
+        "objectsStorage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "storageBackend": {
+              "description": "The storage backend for different objects (assets, old data...) to use. Use `fs` for filesystem, and `s3` for S3.",
+              "type": "string",
+              "enum": [
+                "fs",
+                "s3"
+              ],
+              "default": "fs"
+            },
+            "filesystem": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "directory": {
+                  "type": "string",
+                  "pattern": "^/",
+                  "default": "/opt/data/assets",
+                  "description": "The storage directory to use if you chose the filesystem storage backend."
+                }
+              }
+            },
+            "s3": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "accessKeyID": {
+                  "type": "string",
+                  "description": "The S3 access key ID to use if you chose the S3 storage backend."
+                },
+                "secretAccessKey": {
+                  "type": "string",
+                  "description": "The S3 secret access key to use if you chose the S3 storage backend."
+                },
+                "region": {
+                  "type": "string",
+                  "description": "The S3 region to use if you chose the S3 storage backend."
+                },
+                "bucket": {
+                  "type": "string",
+                  "description": "The name of the S3 bucket to use if you chose the S3 storage backend."
+                },
+                "endpointURI": {
+                  "type": "string",
+                  "description": "The S3 endpoint URI to use if you chose the S3 storage backend."
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The name of an existing secret."
+                },
+                "secretKeys": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "accessKeyIDKey": {
+                      "type": "string",
+                      "default": "",
+                      "description": "The S3 access key ID to use from an existing secret."
+                    },
+                    "secretAccessKey": {
+                      "type": "string",
+                      "default": "",
+                      "description": "The S3 secret access key to use from an existing secret."
+                    },
+                    "endpointURIKey": {
+                      "type": "string",
+                      "default": "",
+                      "description": "The S3 endpoint URI to use from an existing secret."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "storageBackend": {
+                "const": "s3"
+              }
+            },
+            "required": [
+              "storageBackend"
+            ]
+          },
+          "then": {
+            "required": [
+              "s3"
+            ],
+            "properties": {
+              "s3": {
+                "required": [
+                  "bucket"
+                ],
+                "properties": {
+                  "bucket": {
+                    "minLength": 1,
+                    "description": "Required when storageBackend is s3."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fileDataBackend": {
+          "description": "Define the strategy (backend) for internal file data storage of Penpot. Use \"legacy-db\" (default) the current behaviour, \"db\" to use an specific table in the database (future default) and \"storage\" to use the predefined objects storage system (S3, file system,...)",
+          "type": "string",
+          "enum": [
+            "legacy-db",
+            "db",
+            "storage"
+          ],
+          "default": "legacy-db"
+        },
+        "httpServerMaxBodySize": {
+          "description": "Defines the maximum size of HTTP request bodies (in bytes) that penpot will accept from clients. It controls how large files or data payloads can be when uploading files, submitting forms, or making API requests. It also helps protect against denial-of-service attacks by rejecting oversized requests.\nDefault value for Penpot is 367001600 bytes (~350 MB). See [Nginx documentation]( https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size).",
+          "type": [
+            "string",
+            "integer"
+          ],
+          "pattern": "^[0-9]+$",
+          "default": "367001600"
+        },
+        "smtp": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "description": "Whether to enable SMTP configuration. You also need to add the 'enable-smtp' flag to the PENPOT_FLAGS variable.",
+              "type": "boolean",
+              "default": false
+            },
+            "defaultFrom": {
+              "type": "string",
+              "description": "The SMTP default email to send from."
+            },
+            "defaultReplyTo": {
+              "type": "string",
+              "description": "The SMTP default email to reply to."
+            },
+            "host": {
+              "type": "string",
+              "description": "The SMTP host to use."
+            },
+            "port": {
+              "type": [
+                "string",
+                "integer",
+                "null"
+              ],
+              "pattern": "^([0-9]{1,5})?$",
+              "description": "The SMTP host port to use."
+            },
+            "username": {
+              "type": "string",
+              "description": "The SMTP username to use."
+            },
+            "password": {
+              "type": "string",
+              "description": "The SMTP password to use."
+            },
+            "tls": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to use TLS for the SMTP connection."
+            },
+            "ssl": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to use SSL for the SMTP connection."
+            },
+            "existingSecret": {
+              "type": "string",
+              "default": "",
+              "description": "The name of an existing secret."
+            },
+            "secretKeys": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "usernameKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The SMTP username to use from an existing secret."
+                },
+                "passwordKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The SMTP password to use from an existing secret."
+                }
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          },
+          "then": {
+            "required": [
+              "host"
+            ],
+            "properties": {
+              "host": {
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "providers": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "google": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to enable Google configuration. To enable Google auth, add `enable-login-with-google` to the flags."
+                },
+                "clientID": {
+                  "type": "string",
+                  "description": "The Google client ID to use. To enable Google auth, add `enable-login-with-google` to the flags."
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "description": "The Google client secret to use. To enable Google auth, add `enable-login-with-google` to the flags."
+                }
+              }
+            },
+            "github": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to enable GitHub configuration. To enable GitHub auth, also add `enable-login-with-github` to the flags."
+                },
+                "clientID": {
+                  "type": "string",
+                  "description": "The GitHub client ID to use."
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "description": "The GitHub client secret to use."
+                }
+              }
+            },
+            "gitlab": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to enable GitLab configuration. To enable GitLab auth, also add `enable-login-with-gitlab` to the flags."
+                },
+                "baseURI": {
+                  "type": "string",
+                  "default": "https://gitlab.com",
+                  "description": "The GitLab base URI to use."
+                },
+                "clientID": {
+                  "type": "string",
+                  "description": "The GitLab client ID to use."
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "description": "The GitLab client secret to use."
+                }
+              }
+            },
+            "oidc": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to enable OIDC configuration. To enable OpenID Connect auth, also add `enable-login-with-oidc` to the flags."
+                },
+                "baseURI": {
+                  "type": "string",
+                  "description": "The OpenID Connect base URI to use."
+                },
+                "clientID": {
+                  "type": "string",
+                  "description": "The OpenID Connect client ID to use."
+                },
+                "clientSecret": {
+                  "type": "string",
+                  "description": "The OpenID Connect client secret to use."
+                },
+                "authURI": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect auth URI to use. Auto discovered if not provided."
+                },
+                "tokenURI": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect token URI to use. Auto discovered if not provided."
+                },
+                "userURI": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect user URI to use. Auto discovered if not provided."
+                },
+                "roles": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect roles to use. If no role is provided, role checking is  disabled (default role values are set below, to disable role verification, send an empty string)."
+                },
+                "rolesAttribute": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect roles attribute to use. If not provided, the role checking will be disabled."
+                },
+                "scopes": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect scopes to use. These settings allow overwriting the required scopes, use with caution because penpot requires at least `name` and `email` attrs found on the user info. Optional, defaults to `openid profile`."
+                },
+                "nameAttribute": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect name attribute to use. If not provided, the `name` prop will be used."
+                },
+                "emailAttribute": {
+                  "type": "string",
+                  "description": "Optional OpenID Connect email attribute to use. If not provided, the `email` prop will be used."
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "enabled"
+                ]
+              },
+              "then": {
+                "required": [
+                  "baseURI"
+                ],
+                "properties": {
+                  "baseURI": {
+                    "minLength": 1
+                  }
+                }
+              }
+            },
+            "ldap": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to enable LDAP configuration. To enable LDAP, also add `enable-login-with-ldap` to the flags."
+                },
+                "host": {
+                  "type": "string",
+                  "default": "ldap",
+                  "description": "The LDAP host to use."
+                },
+                "port": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/port"
+                    }
+                  ],
+                  "description": "The LDAP port to use."
+                },
+                "ssl": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to use SSL for the LDAP connection."
+                },
+                "startTLS": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Whether to utilize StartTLS for the LDAP connection."
+                },
+                "baseDN": {
+                  "type": "string",
+                  "description": "The LDAP base DN to use."
+                },
+                "bindDN": {
+                  "type": "string",
+                  "description": "The LDAP bind DN to use."
+                },
+                "bindPassword": {
+                  "type": "string",
+                  "description": "The LDAP bind password to use."
+                },
+                "userQuery": {
+                  "type": "string",
+                  "description": "The LDAP user query to use."
+                },
+                "attributesUsername": {
+                  "type": "string",
+                  "description": "The LDAP attributes username to use."
+                },
+                "attributesEmail": {
+                  "type": "string",
+                  "description": "The LDAP attributes email to use."
+                },
+                "attributesFullname": {
+                  "type": "string",
+                  "description": "The LDAP attributes fullname to use."
+                },
+                "attributesPhoto": {
+                  "type": "string",
+                  "description": "The LDAP attributes photo format to use."
+                }
+              }
+            },
+            "existingSecret": {
+              "type": "string",
+              "default": "",
+              "description": "The name of an existing secret to use."
+            },
+            "secretKeys": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "googleClientIDKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The Google client ID key to use from an existing secret."
+                },
+                "googleClientSecretKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The Google client secret key to use from an existing secret."
+                },
+                "githubClientIDKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The GitHub client ID key to use from an existing secret."
+                },
+                "githubClientSecretKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The GitHub client secret key to use from an existing secret."
+                },
+                "gitlabClientIDKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The GitLab client ID key to use from an existing secret."
+                },
+                "gitlabClientSecretKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The GitLab client secret key to use from an existing secret."
+                },
+                "oidcClientIDKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The OpenID Connect client ID key to use from an existing secret."
+                },
+                "oidcClientSecretKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The OpenID Connect client secret key to use from an existing secret."
+                },
+                "ldapBindPasswordKey": {
+                  "type": "string",
+                  "default": "",
+                  "description": "The LDAP admin bind password to use from an exsiting secret"
+                }
+              }
+            }
+          }
+        },
+        "autoFileSnapshot": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "every": {
+              "description": "How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.",
+              "type": "integer",
+              "minimum": 1,
+              "default": 5
+            },
+            "timeout": {
+              "description": "If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.",
+              "type": "string",
+              "pattern": "^[0-9]+(ms|s|m|h|d)$",
+              "default": "3h"
+            }
+          }
+        },
+        "extraEnvs": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/envVars"
+            }
+          ],
+          "description": "Specify any additional environment values you want to provide to all the containers (frontend, backend and exporter) in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)"
+        }
+      }
+    },
+    "backend": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/component"
+        }
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "replicaCount": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/replicaCount"
+            }
+          ],
+          "description": "The number of replicas to deploy."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/updateStrategy"
+        },
+        "service": {
+          "$ref": "#/definitions/service"
+        },
+        "deploymentAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Deployment"
+        },
+        "podLabels": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of labels to be applied to the controller Pods"
+        },
+        "podAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Pods"
+        },
+        "podSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "containerSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)"
+        },
+        "nodeSelector": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/tolerations"
+        },
+        "resources": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/resources"
+            }
+          ],
+          "description": "Penpot backend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)"
+        },
+        "startupProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "pdb": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/pdb"
+            }
+          ],
+          "description": "Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)"
+        },
+        "autoscaling": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/autoscaling"
+            }
+          ],
+          "description": "Configure autoscaling for the backend pods."
+        },
+        "extraEnvs": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/envVars"
+            }
+          ],
+          "description": "Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)"
+        },
+        "volumes": {
+          "$ref": "#/definitions/volumes"
+        },
+        "volumeMounts": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/volumeMounts"
+            }
+          ],
+          "description": "Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)"
+        }
+      }
+    },
+    "frontend": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/component"
+        }
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/image"
+        },
+        "replicaCount": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/replicaCount"
+            }
+          ],
+          "description": "The number of replicas to deploy."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/updateStrategy"
+        },
+        "service": {
+          "$ref": "#/definitions/service"
+        },
+        "deploymentAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Deployment"
+        },
+        "podLabels": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of labels to be applied to the controller Pods"
+        },
+        "podAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Pods"
+        },
+        "podSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "containerSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)"
+        },
+        "nodeSelector": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/tolerations"
+        },
+        "resources": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/resources"
+            }
+          ],
+          "description": "Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)"
+        },
+        "pdb": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/pdb"
+            }
+          ],
+          "description": "Configure Pod Disruption Budget for the frontend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)"
+        },
+        "autoscaling": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/autoscaling"
+            }
+          ],
+          "description": "Configure autoscaling for the frontend pods."
+        },
+        "extraEnvs": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/envVars"
+            }
+          ],
+          "description": "Specify any additional environment values you want to provide to the frontend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)"
+        },
+        "volumes": {
+          "$ref": "#/definitions/volumes"
+        },
+        "volumeMounts": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/volumeMounts"
+            }
+          ],
+          "description": "Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)"
+        }
+      }
+    },
+    "exporter": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/component"
+        }
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/imageWithDeprecatedPullPolicy"
+        },
+        "replicaCount": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/replicaCount"
+            }
+          ],
+          "description": "The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/updateStrategy"
+        },
+        "service": {
+          "$ref": "#/definitions/service"
+        },
+        "deploymentAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Deployment"
+        },
+        "podLabels": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of labels to be applied to the controller Pods"
+        },
+        "podAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Pods"
+        },
+        "podSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "containerSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)"
+        },
+        "nodeSelector": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/tolerations"
+        },
+        "resources": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/resources"
+            }
+          ],
+          "description": "Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)"
+        },
+        "pdb": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/pdb"
+            }
+          ],
+          "description": "Configure Pod Disruption Budget for the exporter pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)"
+        },
+        "autoscaling": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/autoscaling"
+            }
+          ],
+          "description": "Configure autoscaling for the exporter pods."
+        },
+        "extraEnvs": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/envVars"
+            }
+          ],
+          "description": "Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)"
+        },
+        "volumes": {
+          "$ref": "#/definitions/volumes"
+        },
+        "volumeMounts": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/volumeMounts"
+            }
+          ],
+          "description": "Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)"
+        }
+      }
+    },
+    "mcp": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/component"
+        }
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "$ref": "#/definitions/imageWithDeprecatedPullPolicy"
+        },
+        "replicaCount": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/replicaCount"
+            }
+          ],
+          "description": "The number of replicas to deploy."
+        },
+        "updateStrategy": {
+          "$ref": "#/definitions/updateStrategy"
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/serviceType"
+                }
+              ],
+              "description": "The service type to create."
+            },
+            "httpPort": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/port"
+                }
+              ],
+              "description": "The HTTP/SSE port for AI clients (e.g. Claude)."
+            },
+            "wsPort": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/port"
+                }
+              ],
+              "description": "The WebSocket port for the Penpot MCP plugin."
+            },
+            "annotations": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/stringMap"
+                }
+              ],
+              "description": "Mapped annotations for the service."
+            }
+          }
+        },
+        "deploymentAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Deployment"
+        },
+        "podLabels": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of labels to be applied to the controller Pods"
+        },
+        "podAnnotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the controller Pods"
+        },
+        "podSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "containerSecurityContext": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/securityContext"
+            }
+          ],
+          "description": "Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)"
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)"
+        },
+        "nodeSelector": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)"
+        },
+        "tolerations": {
+          "$ref": "#/definitions/tolerations"
+        },
+        "resources": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/resources"
+            }
+          ],
+          "description": "Penpot MCP server resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)"
+        },
+        "pdb": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/pdb"
+            }
+          ],
+          "description": "Configure Pod Disruption Budget for the MCP server pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)"
+        },
+        "autoscaling": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/autoscaling"
+            }
+          ],
+          "description": "Configure autoscaling for the MCP server pods."
+        },
+        "extraEnvs": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/envVars"
+            }
+          ],
+          "description": "Specify any additional environment values you want to provide to the MCP server container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)"
+        },
+        "volumes": {
+          "$ref": "#/definitions/volumes"
+        },
+        "volumeMounts": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/volumeMounts"
+            }
+          ],
+          "description": "Extra volumes to be mounted in the container. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)"
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "assets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "description": "Enable Penpot objects persistence using Persistent Volume Claims.",
+              "type": "boolean",
+              "default": true
+            },
+            "storageClass": {
+              "description": "Penpot objects persistent Volume storage class.\nIf defined, storageClassName: <storageClass>.\nIf undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": ""
+            },
+            "size": {
+              "description": "Penpot objects persistent Volume size.",
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$",
+              "default": "20Gi"
+            },
+            "existingClaim": {
+              "description": "The name of an existing PVC to use for Penpot objects persistence.",
+              "type": "string",
+              "default": ""
+            },
+            "accessModes": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "ReadWriteOnce",
+                  "ReadOnlyMany",
+                  "ReadWriteMany",
+                  "ReadWriteOncePod"
+                ]
+              },
+              "default": [
+                "ReadWriteOnce"
+              ],
+              "description": "Penpot objects persistent Volume access modes."
+            },
+            "annotations": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/stringMap"
+                }
+              ],
+              "description": "Penpot objects persistent Volume Claim annotations."
+            }
+          }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API (HTTPRoute) parameters.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Gateway API HTTPRoute support."
+        },
+        "annotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Extra annotations for the HTTPRoute."
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Hostnames exposed by the HTTPRoute."
+        },
+        "parentRefs": {
+          "description": "ParentRefs for attaching the HTTPRoute to one or more Gateways.\nExample:\nparentRefs:\n  - name: shared-gateway\n    namespace: infra\n    sectionName: http",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "sectionName": {
+                "type": "string"
+              },
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "port": {
+                "$ref": "#/definitions/port"
+              }
+            }
+          }
+        },
+        "pathMatchType": {
+          "type": "string",
+          "enum": [
+            "PathPrefix",
+            "Exact",
+            "RegularExpression"
+          ],
+          "default": "PathPrefix",
+          "description": "Path match type for the HTTPRoute.\nCommon values: PathPrefix, Exact"
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^/",
+          "default": "/",
+          "description": "Path value for the HTTPRoute match."
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "additionalProperties": true,
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Optional filters for the HTTPRoute rules.\nExample:\nfilters:\n  - type: RequestHeaderModifier\n    requestHeaderModifier:\n      set:\n        - name: X-Forwarded-Proto\n          value: https"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Enable (frontend) Ingress Controller.",
+          "type": "boolean",
+          "default": false
+        },
+        "className": {
+          "type": "string",
+          "default": "",
+          "description": "The Ingress className."
+        },
+        "annotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Mapped annotations for the ingress crontroller.\nE.g.\nannotations:\n  kubernetes.io/ingress.class: nginx\n  kubernetes.io/tls-acme: \"true\""
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^/",
+          "default": "/",
+          "description": "Root path for every hosts."
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": [
+            "penpot.example.com"
+          ],
+          "description": "Array style hosts for the (frontend) ingress crontroller."
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "secretName": {
+                "type": "string",
+                "minLength": 1
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "default": [],
+          "description": "Array style TLS secrets for the (frontend) ingress crontroller.\nE.g.\ntls:\n  - secretName: penpot.example.com-tls\n    hosts:\n      - penpot.example.com"
+        }
+      },
+      "if": {
+        "properties": {
+          "enabled": {
+            "const": true
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "then": {
+        "required": [
+          "hosts"
+        ],
+        "properties": {
+          "hosts": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    "route": {
+      "type": "object",
+      "description": "OpenShift/OKD Route parameters.",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Openshift/OKD Route. Check [the official doc](https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html). When it is enabled, all fsGroup and runAsUser must be changed to null."
+        },
+        "annotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "An optional map of annotations to be applied to the route."
+        },
+        "host": {
+          "type": "string",
+          "default": "penpot.example.com",
+          "description": "The default external hostname to access to the penpot app."
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "Define a path to use Path-based routes."
+        },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "terminationType": {
+              "type": "string",
+              "enum": [
+                "edge",
+                "passthrough",
+                "reencrypt"
+              ]
+            },
+            "terminationPolicy": {
+              "type": "string",
+              "enum": [
+                "Allow",
+                "Redirect",
+                "None"
+              ]
+            },
+            "certificate": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "caCertificate": {
+              "type": "string"
+            },
+            "destinationCACertificate": {
+              "type": "string"
+            }
+          },
+          "description": "A Map with TLS configuration for the route.\nE.g.\ntls:\n  terminationType: edge\n  terminationPolicy: Redirect"
+        },
+        "wildcardPolicy": {
+          "type": "string",
+          "enum": [
+            "None",
+            "Subdomain"
+          ],
+          "default": "None",
+          "description": "Define the wildcard policy (None, Subdomain, ...)"
+        }
+      },
+      "if": {
+        "properties": {
+          "enabled": {
+            "const": true
+          }
+        },
+        "required": [
+          "enabled"
+        ]
+      },
+      "then": {
+        "required": [
+          "host"
+        ],
+        "properties": {
+          "host": {
+            "minLength": 1
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "stringMap": {
+      "description": "Map of string keys and string values (labels/annotations).",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^[0-9]{1,5}$"
+    },
+    "serviceType": {
+      "type": "string",
+      "enum": [
+        "ClusterIP",
+        "NodePort",
+        "LoadBalancer",
+        "ExternalName"
+      ],
+      "default": "ClusterIP"
+    },
+    "quantity": {
+      "type": [
+        "string",
+        "number"
+      ],
+      "pattern": "^[0-9]+(\\.[0-9]+)?(m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$"
+    },
+    "intOrPercent": {
+      "type": [
+        "integer",
+        "string",
+        "null"
+      ],
+      "pattern": "^([0-9]+|[0-9]{1,3}%)$"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "description": "The Docker repository to pull the image from.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "description": "The image tag to use.",
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "digest": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/imagePullPolicy"
+            }
+          ],
+          "description": "The image pull policy to use."
+        }
+      }
+    },
+    "imagePullPolicy": {
+      "type": "string",
+      "enum": [
+        "Always",
+        "Never",
+        "IfNotPresent"
+      ],
+      "default": "IfNotPresent",
+      "description": "The image pull policy to use."
+    },
+    "replicaCount": {
+      "description": "Number of replicas to deploy. Ignored when the HPA is enabled.",
+      "type": "integer",
+      "minimum": 0,
+      "default": 1
+    },
+    "updateStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "RollingUpdate",
+            "Recreate"
+          ],
+          "default": "RollingUpdate"
+        },
+        "rollingUpdate": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "maxSurge": {
+              "$ref": "#/definitions/intOrPercent"
+            },
+            "maxUnavailable": {
+              "$ref": "#/definitions/intOrPercent"
+            }
+          }
+        }
+      },
+      "description": "The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)\nE.g.\nupdateStrategy:\n  type: RollingUpdate\n  rollingUpdate:\n    maxSurge: 25%\n    maxUnavailable: 25%"
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/serviceType"
+            }
+          ],
+          "description": "The service type to create."
+        },
+        "port": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/port"
+            }
+          ],
+          "description": "The service port to use."
+        },
+        "annotations": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/stringMap"
+            }
+          ],
+          "description": "Mapped annotations for the service."
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limits": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/resourceList"
+            }
+          ],
+          "description": "The resources limits for the Penpot containers."
+        },
+        "requests": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/resourceList"
+            }
+          ],
+          "description": "The requested resources for the Penpot containers."
+        }
+      },
+      "default": {}
+    },
+    "resourceList": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/quantity"
+      },
+      "properties": {
+        "cpu": {
+          "$ref": "#/definitions/quantity"
+        },
+        "memory": {
+          "$ref": "#/definitions/quantity"
+        },
+        "ephemeral-storage": {
+          "$ref": "#/definitions/quantity"
+        }
+      },
+      "default": {}
+    },
+    "securityContext": {
+      "description": "Pod or container security context. Values may be set to null (e.g. on OpenShift).",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "runAsUser": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "runAsGroup": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "fsGroup": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "runAsNonRoot": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "allowPrivilegeEscalation": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "readOnlyRootFilesystem": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "privileged": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "add": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "seccompProfile": {
+          "type": "object"
+        },
+        "seLinuxOptions": {
+          "type": "object"
+        }
+      }
+    },
+    "probe": {
+      "description": "Startup probe for the Penpot backend containers. Tolerates up to 30 * 10 = 300 seconds = 5 Minutes. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "httpGet": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "port": {
+              "type": [
+                "integer",
+                "string"
+              ]
+            },
+            "scheme": {
+              "type": "string",
+              "enum": [
+                "HTTP",
+                "HTTPS"
+              ]
+            },
+            "host": {
+              "type": "string"
+            },
+            "httpHeaders": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "tcpSocket": {
+          "type": "object"
+        },
+        "exec": {
+          "type": "object"
+        },
+        "grpc": {
+          "type": "object"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "pdb": {
+      "description": "PodDisruptionBudget configuration.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Pod Disruption Budget for the pods."
+        },
+        "minAvailable": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/intOrPercent"
+            }
+          ],
+          "description": "(int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, \"10%\")."
+        },
+        "maxUnavailable": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/intOrPercent"
+            }
+          ],
+          "description": "(int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, \"10%\")."
+        }
+      },
+      "not": {
+        "type": "object",
+        "required": [
+          "minAvailable",
+          "maxUnavailable"
+        ],
+        "properties": {
+          "minAvailable": {
+            "not": {
+              "type": "null"
+            }
+          },
+          "maxUnavailable": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hpa": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored."
+            },
+            "minReplicas": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "description": "Minimum number of replicas."
+            },
+            "maxReplicas": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 5,
+              "description": "Maximum number of replicas."
+            },
+            "metrics": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": true,
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Resource",
+                      "Pods",
+                      "Object",
+                      "External",
+                      "ContainerResource"
+                    ]
+                  }
+                }
+              },
+              "description": "Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)"
+            }
+          }
+        },
+        "vpa": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster."
+            },
+            "updateMode": {
+              "type": "string",
+              "enum": [
+                "Off",
+                "Initial",
+                "Recreate",
+                "Auto"
+              ],
+              "default": "Auto",
+              "description": "VPA update mode. One of: \"Off\" (recommendations only), \"Initial\", \"Auto\". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)"
+            },
+            "resourcePolicy": {
+              "type": "object",
+              "default": {},
+              "description": "VPA resource policy for the containers."
+            }
+          }
+        }
+      }
+    },
+    "envVars": {
+      "description": "Additional environment variables, following the Kubernetes EnvVar specification.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
+          },
+          "valueFrom": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "tolerations": {
+      "description": "Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "Exists",
+              "Equal"
+            ]
+          },
+          "value": {
+            "type": "string"
+          },
+          "effect": {
+            "type": "string",
+            "enum": [
+              "NoSchedule",
+              "PreferNoSchedule",
+              "NoExecute"
+            ]
+          },
+          "tolerationSeconds": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "volumes": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "description": "Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)"
+    },
+    "volumeMounts": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "mountPath"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "mountPath": {
+            "type": "string",
+            "minLength": 1
+          },
+          "subPath": {
+            "type": "string"
+          },
+          "readOnly": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "component": {
+      "description": "Common constraints shared by the backend, frontend, exporter and mcp components.",
+      "type": "object",
+      "if": {
+        "properties": {
+          "autoscaling": {
+            "type": "object",
+            "properties": {
+              "hpa": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "enabled"
+                ]
+              }
+            },
+            "required": [
+              "hpa"
+            ]
+          }
+        },
+        "required": [
+          "autoscaling"
+        ]
+      },
+      "then": {
+        "properties": {
+          "autoscaling": {
+            "properties": {
+              "hpa": {
+                "required": [
+                  "minReplicas",
+                  "maxReplicas"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "imageWithDeprecatedPullPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "description": "The Docker repository to pull the image from.",
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "description": "The image tag to use.",
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "digest": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/imagePullPolicy"
+            }
+          ],
+          "description": "Deprecated, use `pullPolicy` instead. The image pull policy to use. Kept for backwards compatibility: this component historically used a different key name than the backend and frontend. If `pullPolicy` is set it takes precedence, and this key will be removed in a future major version."
+        },
+        "pullPolicy": {
+          "description": "The image pull policy to use. Takes precedence over the deprecated imagePullPolicy.",
+          "$ref": "#/definitions/imagePullPolicy"
+        }
+      },
+      "description": "Image parameters for components that historically used imagePullPolicy. Both keys are accepted; pullPolicy wins when both are set."
+    }
+  }
+}

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -4,7 +4,7 @@
 global:
   compatibility:
     openshift:
-      # Adapt Penpot workload securityContext sections to OpenShift restricted-v2 SCC by omitting runAsUser, runAsGroup and fsGroup and letting the platform assign allowed IDs. Possible values: auto (apply when an OpenShift Route API is detected), force (perform the adaptation always), disabled (do not perform adaptation)
+      # -- Adapt Penpot workload securityContext sections to OpenShift restricted-v2 SCC by omitting runAsUser, runAsGroup and fsGroup and letting the platform assign allowed IDs. Possible values: auto (apply when an OpenShift Route API is detected), force (perform the adaptation always), disabled (do not perform adaptation)
       # @section -- Global parameters
       adaptSecurityContext: "auto"
   # -- Global Docker registry secret names.
@@ -36,7 +36,7 @@ config:
   # **IMPORTANT:** Set `disable-secure-session-cookies` in the flags if you plan on serving it on a non HTTPS domain.
   # @section -- Configuration parameters
   publicUri: "http://penpot.example.com"
-  # -- The feature flags to enable. Check [the official docs](https://help.penpot.app/technical-guide/configuration/) for more info.
+  # -- The feature flags to enable. Every entry must be prefixed with `enable-` or `disable-`: any other token is silently ignored, and unknown flag names are accepted without complaint, so a typo is a no-op rather than an error. The available flags change between Penpot versions, check [the official docs](https://help.penpot.app/technical-guide/configuration/) for the list matching your appVersion.
   # @section -- Configuration parameters
   flags: "enable-registration enable-login-with-password disable-email-verification enable-smtp enable-mcp"
   # -- A random secret key needed for persistent user sessions. Generate with `python3 -c "import secrets; print(secrets.token_urlsafe(64))"` for example.
@@ -369,17 +369,23 @@ backend:
   # @section -- Backend parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+  # E.g.
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
   # @section -- Backend parameters
   updateStrategy:
     type: RollingUpdate
   service:
-    # -- The http service type to create.
+    # -- The service type to create.
     # @section -- Backend parameters
     type: ClusterIP
-    # -- The http service port to use.
+    # -- The service port to use.
     # @section -- Backend parameters
     port: 6060
-    # -- Mapped annotations for the backend service
+    # -- Mapped annotations for the service.
     # @section -- Backend parameters
     annotations: {}
   # -- An optional map of annotations to be applied to the controller Deployment
@@ -417,10 +423,10 @@ backend:
   # -- Penpot backend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
   # @section -- Backend parameters
   resources:
-    # -- The resources limits for the Penpot backend containers
+    # -- The resources limits for the Penpot containers.
     # @section -- Backend parameters
     limits: {}
-    # -- The requested resources for the Penpot backend containers
+    # -- The requested resources for the Penpot containers.
     # @section -- Backend parameters
     requests: {}
   # -- Startup probe for the Penpot backend containers. Tolerates up to 30 * 10 = 300 seconds = 5 Minutes. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)
@@ -434,7 +440,7 @@ backend:
   # -- Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
   # @section -- Backend parameters
   pdb:
-    # -- Enable Pod Disruption Budget for the backend pods.
+    # -- Enable Pod Disruption Budget for the pods.
     # @section -- Backend parameters
     enabled: false
     # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
@@ -447,13 +453,13 @@ backend:
   # @section -- Backend parameters
   autoscaling:
     hpa:
-      # -- Enable Horizontal Pod Autoscaler for the backend. When enabled, replicaCount is ignored.
+      # -- Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored.
       # @section -- Backend parameters
       enabled: false
-      # -- Minimum number of backend replicas.
+      # -- Minimum number of replicas.
       # @section -- Backend parameters
       minReplicas: 1
-      # -- Maximum number of backend replicas.
+      # -- Maximum number of replicas.
       # @section -- Backend parameters
       maxReplicas: 5
       # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
@@ -472,13 +478,13 @@ backend:
               type: Utilization
               averageUtilization: 80
     vpa:
-      # -- Enable Vertical Pod Autoscaler for the backend. Requires VPA operator installed in the cluster.
+      # -- Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster.
       # @section -- Backend parameters
       enabled: false
       # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
       # @section -- Backend parameters
       updateMode: "Auto"
-      # -- VPA resource policy for the backend containers.
+      # -- VPA resource policy for the containers.
       # @section -- Backend parameters
       resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
@@ -506,6 +512,12 @@ frontend:
   # @section -- Frontend parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+  # E.g.
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
   # @section -- Frontend parameters
   updateStrategy:
     type: RollingUpdate
@@ -516,7 +528,7 @@ frontend:
     # -- The service port to use.
     # @section -- Frontend parameters
     port: 8080
-    # -- Mapped annotations for the frontend service
+    # -- Mapped annotations for the service.
     # @section -- Frontend parameters
     annotations: {}
   # -- An optional map of annotations to be applied to the controller Deployment
@@ -554,16 +566,16 @@ frontend:
   # -- Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
   # @section -- Frontend parameters
   resources:
-    # -- The resources limits for the Penpot frontend containers
+    # -- The resources limits for the Penpot containers.
     # @section -- Frontend parameters
     limits: {}
-    # -- The requested resources for the Penpot frontend containers
+    # -- The requested resources for the Penpot containers.
     # @section -- Frontend parameters
     requests: {}
   # -- Configure Pod Disruption Budget for the frontend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
   # @section -- Frontend parameters
   pdb:
-    # -- Enable Pod Disruption Budget for the frontend pods.
+    # -- Enable Pod Disruption Budget for the pods.
     # @section -- Frontend parameters
     enabled: false
     # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
@@ -576,13 +588,13 @@ frontend:
   # @section -- Frontend parameters
   autoscaling:
     hpa:
-      # -- Enable Horizontal Pod Autoscaler for the frontend. When enabled, replicaCount is ignored.
+      # -- Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored.
       # @section -- Frontend parameters
       enabled: false
-      # -- Minimum number of frontend replicas.
+      # -- Minimum number of replicas.
       # @section -- Frontend parameters
       minReplicas: 1
-      # -- Maximum number of frontend replicas.
+      # -- Maximum number of replicas.
       # @section -- Frontend parameters
       maxReplicas: 5
       # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
@@ -601,13 +613,13 @@ frontend:
               type: Utilization
               averageUtilization: 80
     vpa:
-      # -- Enable Vertical Pod Autoscaler for the frontend. Requires VPA operator installed in the cluster.
+      # -- Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster.
       # @section -- Frontend parameters
       enabled: false
       # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
       # @section -- Frontend parameters
       updateMode: "Auto"
-      # -- VPA resource policy for the frontend containers.
+      # -- VPA resource policy for the containers.
       # @section -- Frontend parameters
       resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the frontend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
@@ -635,6 +647,12 @@ exporter:
   # @section -- Exporter parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+  # E.g.
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
   # @section -- Exporter parameters
   updateStrategy:
     type: RollingUpdate
@@ -645,7 +663,7 @@ exporter:
     # -- The service port to use.
     # @section -- Exporter parameters
     port: 6061
-    # -- Mapped annotations for the exporter service
+    # -- Mapped annotations for the service.
     # @section -- Exporter parameters
     annotations: {}
   # -- An optional map of annotations to be applied to the controller Deployment
@@ -683,16 +701,16 @@ exporter:
   # -- Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
   # @section -- Exporter parameters
   resources:
-    # -- The resources limits for the Penpot frontend containers
+    # -- The resources limits for the Penpot containers.
     # @section -- Exporter parameters
     limits: {}
-    # -- The requested resources for the Penpot frontend containers
+    # -- The requested resources for the Penpot containers.
     # @section -- Exporter parameters
     requests: {}
   # -- Configure Pod Disruption Budget for the exporter pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
   # @section -- Exporter parameters
   pdb:
-    # -- Enable Pod Disruption Budget for the exporter pods.
+    # -- Enable Pod Disruption Budget for the pods.
     # @section -- Exporter parameters
     enabled: false
     # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
@@ -705,13 +723,13 @@ exporter:
   # @section -- Exporter parameters
   autoscaling:
     hpa:
-      # -- Enable Horizontal Pod Autoscaler for the exporter. When enabled, replicaCount is ignored.
+      # -- Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored.
       # @section -- Exporter parameters
       enabled: false
-      # -- Minimum number of exporter replicas.
+      # -- Minimum number of replicas.
       # @section -- Exporter parameters
       minReplicas: 1
-      # -- Maximum number of exporter replicas.
+      # -- Maximum number of replicas.
       # @section -- Exporter parameters
       maxReplicas: 5
       # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
@@ -730,13 +748,13 @@ exporter:
               type: Utilization
               averageUtilization: 80
     vpa:
-      # -- Enable Vertical Pod Autoscaler for the exporter. Requires VPA operator installed in the cluster.
+      # -- Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster.
       # @section -- Exporter parameters
       enabled: false
       # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
       # @section -- Exporter parameters
       updateMode: "Auto"
-      # -- VPA resource policy for the exporter containers.
+      # -- VPA resource policy for the containers.
       # @section -- Exporter parameters
       resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
@@ -764,6 +782,12 @@ mcp:
   # @section -- MCP parameters
   replicaCount: 1
   # -- The update strategy to apply to the Deployment. Check [the official doc](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy)
+  # E.g.
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
   # @section -- MCP parameters
   updateStrategy:
     type: RollingUpdate
@@ -777,7 +801,7 @@ mcp:
     # -- The WebSocket port for the Penpot MCP plugin.
     # @section -- MCP parameters
     wsPort: 4402
-    # -- Mapped annotations for the MCP service.
+    # -- Mapped annotations for the service.
     # @section -- MCP parameters
     annotations: {}
   # -- An optional map of annotations to be applied to the controller Deployment
@@ -815,16 +839,16 @@ mcp:
   # -- Penpot MCP server resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
   # @section -- MCP parameters
   resources:
-    # -- The resources limits for the Penpot MCP server containers
+    # -- The resources limits for the Penpot containers.
     # @section -- MCP parameters
     limits: {}
-    # -- The requested resources for the Penpot MCP server containers
+    # -- The requested resources for the Penpot containers.
     # @section -- MCP parameters
     requests: {}
   # -- Configure Pod Disruption Budget for the MCP server pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
   # @section -- MCP parameters
   pdb:
-    # -- Enable Pod Disruption Budget for the MCP server pods.
+    # -- Enable Pod Disruption Budget for the pods.
     # @section -- MCP parameters
     enabled: false
     # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
@@ -837,13 +861,13 @@ mcp:
   # @section -- MCP parameters
   autoscaling:
     hpa:
-      # -- Enable Horizontal Pod Autoscaler for the MCP server.
+      # -- Enable Horizontal Pod Autoscaler. When enabled, replicaCount is ignored.
       # @section -- MCP parameters
       enabled: false
-      # -- Minimum number of MCP server replicas.
+      # -- Minimum number of replicas.
       # @section -- MCP parameters
       minReplicas: 1
-      # -- Maximum number of MCP server replicas.
+      # -- Maximum number of replicas.
       # @section -- MCP parameters
       maxReplicas: 5
       # -- Metrics to use for HPA scaling. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
@@ -862,13 +886,13 @@ mcp:
               type: Utilization
               averageUtilization: 80
     vpa:
-      # -- Enable Vertical Pod Autoscaler for the MCP server. Requires VPA operator installed in the cluster.
+      # -- Enable Vertical Pod Autoscaler. Requires VPA operator installed in the cluster.
       # @section -- MCP parameters
       enabled: false
       # -- VPA update mode. One of: "Off" (recommendations only), "Initial", "Auto". Check [the official doc](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
       # @section -- MCP parameters
       updateMode: "Auto"
-      # -- VPA resource policy for the MCP server containers.
+      # -- VPA resource policy for the containers.
       # @section -- MCP parameters
       resourcePolicy: {}
   # -- Specify any additional environment values you want to provide to the MCP server container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)

--- a/scripts/check-flags.py
+++ b/scripts/check-flags.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Cross-check the Penpot flags used by the chart against the upstream flag list.
+
+The schema enforces the *syntax* of `config.flags` (every token prefixed with
+enable-/disable-). It cannot know which flag names exist, because Penpot's parser
+accepts any name and silently does nothing with unknown ones, so a typo is a
+no-op rather than an error.
+
+This script reads the real list from the penpot repo, pinned to the tag matching
+Chart.yaml's appVersion:
+
+    https://github.com/penpot/penpot/blob/main/common/src/app/common/flags.cljc
+
+**It reports warnings and exits 0 by default, on purpose.** Flags come and go
+between Penpot versions, the file has moved before, and the chart may point at a
+version that is not tagged yet. None of that should turn a CI run red on an
+unrelated change; it should just leave a note on the PR. Pass --strict if you
+want the mismatches to fail the build.
+
+Usage:
+    scripts/check-flags.py --chart charts/penpot
+    scripts/check-flags.py --chart charts/penpot --strict
+    scripts/check-flags.py --chart charts/penpot --flags-file /tmp/flags.cljc
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import pathlib
+import re
+import sys
+import urllib.request
+
+FLAGS_PATH = "common/src/app/common/flags.cljc"
+RAW = "https://raw.githubusercontent.com/penpot/penpot/{ref}/" + FLAGS_PATH
+FLAG_SETS = ("login", "email", "varia")
+
+# Flags that are real and documented but never reach the Clojure parser, so they
+# are absent from flags.cljc. `enable-air-gapped-conf` for instance is read by
+# the nginx entrypoint of the frontend image. Anything consumed outside the
+# parser has to be listed here by hand.
+EXTRA_KNOWN = {"air-gapped-conf"}
+
+
+def log(level: str, msg: str, file: str | None = None) -> None:
+    """Print a GitHub Actions annotation, or a plain line when run locally."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        where = f" file={file}::" if file else "::"
+        print(f"::{level}{where}{msg}")
+    else:
+        print(f"{level.upper()}: {msg}" + (f" ({file})" if file else ""))
+
+
+def read_yaml(path: str):
+    import yaml
+
+    with open(path) as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def fetch_flags_source(ref: str) -> tuple[str, str] | None:
+    """Return (source, ref_used), or None if it could not be retrieved.
+
+    Falls back to main when the tag does not exist yet (unreleased chart) or the
+    file is not there under that ref.
+    """
+    for candidate in (ref, "main"):
+        try:
+            with urllib.request.urlopen(RAW.format(ref=candidate), timeout=30) as r:
+                return r.read().decode("utf-8"), candidate
+        except Exception as exc:  # noqa: BLE001 - any network/HTTP problem
+            log("warning", f"could not fetch flags.cljc at ref {candidate}: {exc}")
+    return None
+
+
+def _balanced(src: str, start: int, opening: str, closing: str) -> str:
+    """Return the substring of the form delimited at `start`, brackets balanced."""
+    depth = 0
+    for i in range(start, len(src)):
+        if src[i] == opening:
+            depth += 1
+        elif src[i] == closing:
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise ValueError("unbalanced form in flags.cljc")
+
+
+def parse_known_flags(src: str) -> set[str]:
+    """Collect the flag names from the login/email/varia sets and the defaults.
+
+    Returns an empty set if the upstream layout no longer matches; the caller
+    treats that as "cannot check" rather than as a failure.
+    """
+    src = re.sub(r";;.*", "", src)  # drop comments, they mention flags too
+    known: set[str] = set()
+
+    for name in FLAG_SETS:
+        m = re.search(rf"\(def\s+{name}\b", src)
+        if not m:
+            log("warning", f"could not find the '{name}' flag set upstream, "
+                           "the file layout probably changed")
+            return set()
+        body = _balanced(src, src.index("#{", m.end()) + 1, "{", "}")
+        known |= set(re.findall(r":([a-z0-9]+(?:-[a-z0-9]+)*)", body))
+
+    # `default` lists already-prefixed flags and includes some (feature-*) that
+    # are not members of the sets above.
+    m = re.search(r"\(def\s+default\b", src)
+    if m:
+        body = _balanced(src, src.index("[", m.end()), "[", "]")
+        for flag in re.findall(r":(?:enable|disable)-([a-z0-9]+(?:-[a-z0-9]+)*)", body):
+            known.add(flag)
+
+    return known
+
+
+def flags_in(values: dict) -> list[str]:
+    raw = ((values or {}).get("config") or {}).get("flags")
+    return raw.split() if isinstance(raw, str) else []
+
+
+def resolve_charts(args) -> list[str]:
+    """Charts to act on: the one given, or every chart in the charts directory.
+
+    The repository may grow more charts, so nothing here should assume there is
+    exactly one, or that it is called penpot.
+    """
+    if args.chart:
+        return [args.chart]
+    root = pathlib.Path(args.charts_dir)
+    found = sorted(str(p.parent) for p in root.glob("*/Chart.yaml"))
+    if not found:
+        raise SystemExit(f"error: no charts found under {root}/")
+    return found
+
+
+def chart_flag_files(chart: str) -> list[str]:
+    """values.yaml plus the valid fixtures. Invalid ones are broken on purpose."""
+    files = [os.path.join(chart, "values.yaml")]
+    files += sorted(glob.glob(os.path.join(chart, "tests", "values", "valid", "*.yaml")))
+    return files
+
+
+def check(chart: str, known: set[str], used: str, level: str, strict: bool) -> tuple[bool, int]:
+    failed, warned = False, 0
+    for path in chart_flag_files(chart):
+        for token in flags_in(read_yaml(path)):
+            if not re.fullmatch(r"(enable|disable)-[a-z0-9]+(-[a-z0-9]+)*", token):
+                # Not version dependent: the prefix is how the parser works, so
+                # this one stays fatal.
+                log("error", f"flag '{token}' has no enable-/disable- prefix, "
+                             "Penpot will ignore it", path)
+                failed = True
+            elif token.split("-", 1)[1] not in known:
+                log(level, f"unknown flag '{token}': not defined in penpot@{used}. "
+                           "Either a typo, or a flag added/removed in another version",
+                    path)
+                failed = failed or strict
+                warned += 1
+        print(f"checked {path}")
+    return failed, warned
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chart", help="a single chart directory; defaults to every chart found")
+    ap.add_argument("--charts-dir", default="charts",
+                    help="where to look for charts when --chart is omitted")
+    ap.add_argument("--ref", help="override the penpot ref (defaults to appVersion)")
+    ap.add_argument("--flags-file", help="use a local flags.cljc instead of fetching")
+    ap.add_argument("--strict", action="store_true",
+                    help="fail on unknown flags instead of only warning")
+    args = ap.parse_args()
+    level = "error" if args.strict else "warning"
+
+    # Only charts that actually expose config.flags. Another chart in this
+    # repository may have nothing to do with Penpot feature flags.
+    charts = [c for c in resolve_charts(args)
+              if flags_in(read_yaml(os.path.join(c, "values.yaml")))]
+    if not charts:
+        print("no chart declares config.flags, nothing to check")
+        return 0
+
+    failed, warned = False, 0
+    for chart in charts:
+        meta = read_yaml(os.path.join(chart, "Chart.yaml"))
+        ref = args.ref or str(meta.get("appVersion", "main"))
+
+        if args.flags_file:
+            fetched = open(args.flags_file).read(), args.flags_file
+        else:
+            fetched = fetch_flags_source(ref)
+
+        if fetched is None:
+            log(level, f"{chart}: skipping the flag name check, upstream list unavailable")
+            failed = failed or args.strict
+            continue
+
+        src, used = fetched
+        known = parse_known_flags(src)
+        if known:
+            known |= EXTRA_KNOWN
+        if not known:
+            log(level, f"{chart}: skipping the flag name check, could not parse the list")
+            failed = failed or args.strict
+            continue
+        print(f"{chart}: loaded {len(known)} known flags from {used}")
+
+        chart_failed, chart_warned = check(chart, known, used, level, args.strict)
+        failed = failed or chart_failed
+        warned += chart_warned
+
+    if failed:
+        print("FAILED")
+    elif warned:
+        print(f"{warned} flag(s) not found upstream, see the warnings above")
+    else:
+        print("All flags are valid")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-image-tags.py
+++ b/scripts/check-image-tags.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check that every component image tag matches Chart.yaml's appVersion.
+
+Components are discovered rather than listed, so this keeps working when a chart
+gains a component or when another chart is added to the repository: any
+top-level key holding an `image.tag` is treated as one.
+
+The images of a chart are normally released together, so a version bump that
+misses one of them ships a mismatched deployment. Cheap to check, easy to get
+wrong by hand.
+
+Usage:
+    scripts/check-image-tags.py                       # every chart
+    scripts/check-image-tags.py --chart charts/penpot
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+
+import yaml
+
+
+
+def log(level: str, msg: str, file: str | None = None) -> None:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        where = f" file={file}::" if file else "::"
+        print(f"::{level}{where}{msg}")
+    else:
+        print(f"{level.upper()}: {msg}" + (f" ({file})" if file else ""))
+
+
+def resolve_charts(args) -> list[str]:
+    """Charts to act on: the one given, or every chart in the charts directory.
+
+    The repository may grow more charts, so nothing here should assume there is
+    exactly one, or that it is called penpot.
+    """
+    if args.chart:
+        return [args.chart]
+    root = pathlib.Path(args.charts_dir)
+    found = sorted(str(p.parent) for p in root.glob("*/Chart.yaml"))
+    if not found:
+        raise SystemExit(f"error: no charts found under {root}/")
+    return found
+
+
+def components(values: dict) -> dict[str, str]:
+    """Top-level keys that carry an image.tag, mapped to that tag."""
+    found = {}
+    for key, value in (values or {}).items():
+        if isinstance(value, dict) and isinstance(value.get("image"), dict):
+            tag = value["image"].get("tag")
+            if tag is not None:
+                found[key] = str(tag)
+    return found
+
+
+def check(chart: str) -> bool:
+    values_file = os.path.join(chart, "values.yaml")
+    app_version = str(yaml.safe_load(open(os.path.join(chart, "Chart.yaml")))["appVersion"])
+    found = components(yaml.safe_load(open(values_file)))
+
+    if not found:
+        print(f"{chart}: no components with an image tag, nothing to check")
+        return True
+
+    ok = True
+    for component, tag in sorted(found.items()):
+        if tag != app_version:
+            log("error", f"{component}.image.tag is '{tag}' but appVersion is "
+                         f"'{app_version}'", values_file)
+            ok = False
+        else:
+            print(f"ok: {chart} {component}.image.tag == {app_version}")
+    return ok
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chart", help="a single chart directory; defaults to every chart found")
+    ap.add_argument("--charts-dir", default="charts",
+                    help="where to look for charts when --chart is omitted")
+    args = ap.parse_args()
+
+    return 0 if all([check(c) for c in resolve_charts(args)]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-schema-coverage.py
+++ b/scripts/check-schema-coverage.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Assert every key in values.yaml is declared in values.schema.json.
+
+The schema is deliberately permissive at runtime: unknown top-level keys are
+accepted so that values files carried over from 0.x, YAML anchors and keys read
+by external tooling do not break a user's install.
+
+That leniency should not extend to us. A key added to values.yaml without a
+matching entry in the schema would silently lose its validation and its editor
+hover text, so this check keeps the two in step. Strict here, forgiving there.
+
+    scripts/check-schema-coverage.py --chart charts/penpot
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+
+import yaml
+import json
+
+
+def log(level: str, msg: str, file: str | None = None) -> None:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        where = f" file={file}::" if file else "::"
+        print(f"::{level}{where}{msg}")
+    else:
+        print(f"{level.upper()}: {msg}" + (f" ({file})" if file else ""))
+
+
+def declared_paths(schema: dict) -> set[str]:
+    """Dotted paths the schema describes, following $ref into definitions."""
+    found: set[str] = set()
+
+    def resolve(node, depth=0):
+        while isinstance(node, dict) and "$ref" in node and depth < 10:
+            ref = node["$ref"]
+            if not ref.startswith("#/definitions/"):
+                return node
+            node = schema["definitions"][ref.split("/")[-1]]
+            depth += 1
+        return node
+
+    def walk(node, prefix=""):
+        node = resolve(node)
+        if not isinstance(node, dict):
+            return
+        for key, value in node.get("properties", {}).items():
+            path = f"{prefix}.{key}" if prefix else key
+            found.add(path)
+            walk(value, path)
+        for combinator in ("allOf", "anyOf", "oneOf"):
+            for sub in node.get(combinator, []):
+                walk(sub, prefix)
+
+    walk(schema)
+    return found
+
+
+def value_paths(values) -> set[str]:
+    found: set[str] = set()
+
+    def walk(node, prefix=""):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                path = f"{prefix}.{key}" if prefix else key
+                found.add(path)
+                walk(value, path)
+
+    walk(values)
+    return found
+
+
+def resolve_charts(args) -> list[str]:
+    """Charts to act on: the one given, or every chart in the charts directory.
+
+    The repository may grow more charts, so nothing here should assume there is
+    exactly one, or that it is called penpot.
+    """
+    if args.chart:
+        return [args.chart]
+    root = pathlib.Path(args.charts_dir)
+    found = sorted(str(p.parent) for p in root.glob("*/Chart.yaml"))
+    if not found:
+        raise SystemExit(f"error: no charts found under {root}/")
+    return found
+
+
+def check(chart: str) -> bool:
+    values_file = os.path.join(chart, "values.yaml")
+    schema_file = os.path.join(chart, "values.schema.json")
+
+    if not os.path.exists(schema_file):
+        print(f"{chart}: no values.schema.json, skipping")
+        return True
+
+    values = yaml.safe_load(open(values_file))
+    declared = declared_paths(json.load(open(schema_file)))
+    paths = value_paths(values)
+    missing = sorted(p for p in paths if p not in declared)
+
+    if missing:
+        for path in missing:
+            log("error", f"'{path}' is in values.yaml but not described in "
+                         "values.schema.json", schema_file)
+        print(f"\n{chart}: {len(missing)} key(s) missing from the schema.")
+        return False
+
+    print(f"{chart}: all {len(paths)} keys in values.yaml are described in the schema")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--chart", help="a single chart directory; defaults to every chart found")
+    parser.add_argument("--charts-dir", default="charts",
+                        help="where to look for charts when --chart is omitted")
+    args = parser.parse_args()
+
+    return 0 if all([check(c) for c in resolve_charts(args)]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync-descriptions.py
+++ b/scripts/sync-descriptions.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Sync the helm-docs descriptions from values.yaml into values.schema.json.
+
+values.yaml is the single source of truth for descriptions: helm-docs renders
+them into README.md, and this copies them into the schema so editors show the
+same text on hover. Without it the two drift apart silently.
+
+    scripts/sync-descriptions.py --chart charts/penpot            # write
+    scripts/sync-descriptions.py --chart charts/penpot --check    # verify
+
+Properties reached through a `$ref` live in a single shared node used by all four
+components, so their description can only be synced when every component words it
+the same way. When they disagree - usually because each sentence names its own
+component ("Maximum number of backend replicas") - the definition keeps its
+generic hand-written text and the script reports it, rather than letting the last
+component silently win.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import pathlib
+import re
+import sys
+
+KEY = re.compile(r"^(\s*)([A-Za-z_][\w.-]*):(.*)$")
+DESC_START = re.compile(r"^\s*#\s*--\s?(.*)$")
+COMMENT = re.compile(r"^\s*#\s?(.*)$")
+HELM_DOCS_TAG = re.compile(r"^\s*#\s*@(section|default|ignored|raw|notationType)\b")
+
+
+def log(level: str, msg: str, file: str | None = None) -> None:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        where = f" file={file}::" if file else "::"
+        print(f"::{level}{where}{msg}")
+    else:
+        print(f"{level.upper()}: {msg}" + (f" ({file})" if file else ""))
+
+
+def parse_descriptions(text: str) -> dict[str, str]:
+    """Map dotted path -> helm-docs description for every annotated key."""
+    descriptions: dict[str, str] = {}
+    buffer: list[str] = []
+    stack: list[tuple[int, str]] = []
+
+    for line in text.splitlines():
+        if not line.strip():
+            buffer = []
+            continue
+
+        if line.lstrip().startswith("#"):
+            buffer.append(line)
+            continue
+
+        match = KEY.match(line)
+        if not match:
+            buffer = []
+            continue
+
+        indent, key = len(match.group(1)), match.group(2)
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        stack.append((indent, key))
+        path = ".".join(k for _, k in stack)
+
+        description = extract(buffer)
+        if description:
+            descriptions[path] = description
+        buffer = []
+
+    return descriptions
+
+
+def extract(buffer: list[str]) -> str | None:
+    """Pull the description out of the comment block sitting above a key."""
+    lines: list[str] = []
+    started = False
+
+    for line in buffer:
+        if HELM_DOCS_TAG.match(line):
+            continue  # @section/@default are helm-docs plumbing, not prose
+        start = DESC_START.match(line)
+        if start:
+            started, lines = True, [start.group(1).rstrip()]
+        elif started:
+            comment = COMMENT.match(line)
+            if comment:
+                lines.append(comment.group(1).rstrip())
+
+    if not started:
+        return None
+    return "\n".join(lines).strip() or None
+
+
+def schema_nodes(schema: dict) -> tuple[dict[str, dict], dict[int, list[str]], dict[str, dict]]:
+    """Map dotted path -> schema node, resolving $ref into definitions.
+
+    Also returns, for every node reached through a $ref, the list of paths that
+    share it. A shared node can only take a description all its users agree on.
+    """
+    found: dict[str, dict] = {}
+    shared: dict[int, list[str]] = {}
+    stubs: dict[str, dict] = {}
+
+    def resolve(node):
+        seen = 0
+        while isinstance(node, dict) and "$ref" in node and seen < 10:
+            ref = node["$ref"]
+            if not ref.startswith("#/definitions/"):
+                return node, False
+            node = schema["definitions"][ref.split("/")[-1]]
+            seen += 1
+        return node, seen > 0
+
+    def walk(node, prefix="", inherited=False):
+        if not isinstance(node, dict):
+            return
+        for key, value in node.get("properties", {}).items():
+            path = f"{prefix}.{key}" if prefix else key
+            target, via_ref = resolve(value)
+            is_shared = inherited or via_ref
+            # The description goes on the node the editor actually reads: the
+            # $ref stub carries no text of its own.
+            found[path] = target if via_ref else value
+            if via_ref:
+                # The property itself is a $ref stub, so it can carry its own
+                # description even though the constraints are shared.
+                stubs[path] = value
+            if is_shared:
+                shared.setdefault(id(target if via_ref else value), []).append(path)
+            walk(target, path, is_shared)
+        for combinator in ("allOf", "anyOf", "oneOf"):
+            for sub in node.get(combinator, []):
+                target, via_ref = resolve(sub)
+                walk(target, prefix, inherited or via_ref)
+
+    walk(schema)
+    return found, shared, stubs
+
+
+def resolve_charts(args) -> list[str]:
+    """Charts to act on: the one given, or every chart in the charts directory.
+
+    The repository may grow more charts, so nothing here should assume there is
+    exactly one, or that it is called penpot.
+    """
+    if args.chart:
+        return [args.chart]
+    root = pathlib.Path(args.charts_dir)
+    found = sorted(str(p.parent) for p in root.glob("*/Chart.yaml"))
+    if not found:
+        raise SystemExit(f"error: no charts found under {root}/")
+    return found
+
+
+def sync(chart: str, check: bool) -> bool:
+    values_file = os.path.join(chart, "values.yaml")
+    schema_file = os.path.join(chart, "values.schema.json")
+
+    descriptions = parse_descriptions(open(values_file).read())
+    schema = json.load(open(schema_file), object_pairs_hook=collections.OrderedDict)
+    nodes, shared, stubs = schema_nodes(schema)
+
+    # A node used by several components takes the description only if they all
+    # agree on it; otherwise it keeps the generic hand-written one.
+    conflicts: list[list[str]] = []
+    blocked: set[int] = set()
+    for node_id, paths in shared.items():
+        wanted = {descriptions[p] for p in paths if p in descriptions}
+        if len(wanted) > 1:
+            blocked.add(node_id)
+            conflicts.append(sorted(p for p in paths if p in descriptions))
+
+    changed, stale, wrapped = [], [], []
+    unresolved: list[list[str]] = []
+    for path, node in nodes.items():
+        wanted = descriptions.get(path)
+        if wanted is None:
+            continue
+
+        if id(node) in blocked:
+            stub = stubs.get(path)
+            if stub is None:
+                continue  # a leaf inside a shared definition: no place of its own
+            # draft-07 ignores keywords next to $ref, so wrap it: the constraints
+            # stay shared, the description becomes this property's own.
+            if "$ref" in stub:
+                stub["allOf"] = [collections.OrderedDict([("$ref", stub.pop("$ref"))])]
+                wrapped.append(path)
+            if stub.get("description") != wanted:
+                stub["description"] = wanted
+                changed.append(path)
+            continue
+
+        if node.get("description") != wanted:
+            changed.append(path)
+            node["description"] = wanted
+
+    # Groups where no user could be given its own description.
+    for group in conflicts:
+        remaining = [p for p in group if p not in stubs]
+        if remaining:
+            unresolved.append(remaining)
+
+    # Descriptions the schema carries for keys values.yaml never documents.
+    for path, node in nodes.items():
+        if "description" in node and path not in descriptions:
+            stale.append(path)
+
+    orphans = sorted(set(descriptions) - set(nodes))
+    conflicts.sort()
+
+    if check:
+        if changed:
+            for path in changed:
+                log("error", f"description out of sync with values.yaml: {path}",
+                    schema_file)
+            print(f"\n{len(changed)} description(s) differ. Run "
+                  "scripts/sync-descriptions.py to fix.")
+            return False
+        print(f"{chart}: all {len(descriptions)} descriptions are in sync")
+        return True
+
+    with open(schema_file, "w") as fh:
+        json.dump(schema, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+    print(f"synced {len(changed)} description(s) into {schema_file}")
+    if stale:
+        print(f"\n{len(stale)} schema-only description(s), kept as written "
+              "(no helm-docs comment in values.yaml):")
+        for path in stale:
+            print("  ", path)
+    if wrapped:
+        print(f"\nwrapped {len(wrapped)} $ref(s) in allOf so they can carry their "
+              "own description")
+    if unresolved:
+        total = sum(len(g) for g in unresolved)
+        print(f"\n{total} key(s) in {len(unresolved)} shared definition(s) keep the "
+              "generic description (they are leaves inside a shared node):")
+        for group in unresolved:
+            print("  ", " | ".join(group))
+    if orphans:
+        print(f"\n{len(orphans)} documented key(s) with no schema property:")
+        for path in orphans:
+            print("  ", path)
+    return True
+
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--chart", help="a single chart directory; defaults to every chart found")
+    parser.add_argument("--charts-dir", default="charts",
+                        help="where to look for charts when --chart is omitted")
+    parser.add_argument("--check", action="store_true",
+                        help="report drift and exit non-zero instead of writing")
+    args = parser.parse_args()
+
+    results = []
+    for chart in resolve_charts(args):
+        if not os.path.exists(os.path.join(chart, "values.schema.json")):
+            print(f"{chart}: no values.schema.json, skipping")
+            continue
+        results.append(sync(chart, args.check))
+    return 0 if all(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Add values.schema.json

## The problem

Helm ignores values it doesn't recognise, without saying anything. Today, a
values file containing this:

```yaml
backend:
  replicaCounts: 3
```

installs cleanly and runs one replica. Nothing warns you. The same goes for a
misspelled enum, a number written as a string, or a key that belongs to a
different component. The mistake shows up later as "why didn't that work", and
the values file looks fine.

Helm can catch these, but only if the chart ships a `values.schema.json`. This
adds one.

## What changes for users

Mistyped or misspelled keys now fail at install time, naming the offending key:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
penpot:
- backend: Additional properties are not allowed ('replicaCounts' was unexpected)
```

Editors that understand `yaml-language-server` also get autocompletion and
inline documentation while writing a values file. The chart has been pointing at
this schema from line 1 of `values.yaml` since the beginning — the file just
never existed.

## Does this break anyone?

It shouldn't. Checked against every released version: the `values.yaml` of
1.0.0, 1.4.0 and 1.8.0 all validate with zero errors.

Unknown keys at the *top level* are still accepted on purpose, so a values file
carried over from an old version, a YAML anchor, or a key added by GitOps tooling
won't block anyone's install. The strict checking applies inside the sections the
chart defines (`backend`, `config`, `ingress`, …), which is where the mistakes
actually happen.

Structures that the chart passes straight through to Kubernetes — `resources`,
`affinity`, the securityContexts, `route.tls` — are left open, since Kubernetes
owns those fields, not us.

## What's in the PR

Three commits, each doing one thing:

1. **docs** — tidy up the `values.yaml` descriptions. Also fixes two that
   described the wrong component and one key that was missing its helm-docs
   marker.
2. **feat** — the schema itself with 25 values files: 11 that must be accepted,
   14 that must be rejected and a workflow running all of it
5. **chore** — a script that copies the `values.yaml` descriptions into the
   schema, so the text is written once and can't drift. Wired into pre-commit.

While writing it, a cross-check against the templates turned up a few keys the
chart accepts but no template ever reads — `livenessProbe`, `readinessProbe`,
`startupProbe` on components that don't use it (frontend, e. x.), and 
`autoscaling.hpa.behavior`. Setting them does nothing today. They're not in 
the schema, so they now fail instead of being silently ignored.

---

<details>
<summary><b>How to check it locally</b></summary>

```sh
git fetch origin && git checkout bameda-feat-values-schema
```

**The chart's own values pass:**

```sh
helm lint charts/penpot
```

**Break something and watch it fail.** Put this in `scratch.yaml`:

```yaml
backend:
  replicaCounts: 3
```

```sh
helm lint charts/penpot --values scratch.yaml
```

It should complain about `replicaCounts`. Try a few more: `replicaCount: "3"`
(quoted), `image.pullPolicy: always` (lowercase), `objectsStorage.storageBackend:
minio`.

**The fixtures.** Neither loop should print anything:

```sh
for f in charts/penpot/tests/values/valid/*.yaml; do
  helm lint charts/penpot --values "$f" || echo "UNEXPECTED FAILURE: $f"
done

for f in charts/penpot/tests/values/invalid/*.yaml; do
  helm lint charts/penpot --values "$f" >/dev/null 2>&1 && echo "UNEXPECTED PASS: $f"
done
```

**An old values file still works:**

```sh
git show penpot-1.8.0:charts/penpot/values.yaml > /tmp/old-values.yaml
helm lint charts/penpot --values /tmp/old-values.yaml
```

**In an editor**, open `charts/penpot/values.yaml` in VS Code with the YAML
extension, or in any editor with `yaml-language-server`. Descriptions appear on
hover and <kbd>Ctrl</kbd>+<kbd>Space</kbd> completes key names.

CI runs all of this on every chart in the repo, against two Helm versions.

</details>