### PR TITLE
ci: smoke test gating the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,14 @@ on:
       - "charts/**"
 
 jobs:
+  # Gate: nothing is published unless the chart actually installs and answers on
+  # a real cluster. release is blocked on this, so it holds regardless of how the
+  # push to main happened.
+  smoke-test:
+    uses: ./.github/workflows/smoke-test.yml
+
   release:
+    needs: smoke-test
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,23 +1,35 @@
 ---
-# Bootstrap stub. Its only purpose is to exist on the default branch so the
-# "Run workflow" button appears, which lets the real workflow be dispatched
-# against the branch that is still in review.
-#
-# Dispatching against a branch runs that branch's version of this file, so this
-# placeholder is only ever executed if someone dispatches it against develop.
-# It is replaced wholesale when the smoke test PR merges; nothing to clean up.
-#
-# The inputs are declared here as well as in the real file: the dispatch form is
-# rendered from the default branch, so without them the fields would not appear.
 name: Smoke test
 
+# Reusable so the same install runs in two places: on pull requests for early
+# feedback, and as a gate in release.yml so nothing is ever published without a
+# green install.
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Branch, tag or SHA to test. Defaults to the calling ref.
+        required: false
+        type: string
+      exposure_mode:
+        description: gateway (default) or ingress.
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - charts/penpot/**
+      - devel/**
+      # Only the shell tooling that builds the cluster. The python scripts in
+      # scripts/ belong to the schema workflow and do not need a cluster.
+      - scripts/*.sh
+      - .github/workflows/smoke-test.yml
   workflow_dispatch:
     inputs:
       ref:
         description: >-
           Branch, tag or SHA to test. Leave empty to use the branch selected
-          above.
+          above. Set it to test a ref that does not carry this workflow, or a
+          tag, or a specific commit.
         required: false
         type: string
       exposure_mode:
@@ -29,12 +41,187 @@ on:
           - gateway
           - ingress
 
+env:
+  CLUSTER_NAME: penpot-cluster
+  NAMESPACE: penpot
+  RELEASE: penpot
+  # Gateway API by default: kubernetes/ingress-nginx was archived in March 2026
+  # and receives no CVE patches, so the ingress path is the legacy one here. The
+  # Ingress API itself is not deprecated and the chart still supports it, which
+  # is why the mode remains selectable for manual runs.
+  EXPOSURE_MODE: ${{ inputs.exposure_mode || 'gateway' }}
+
 jobs:
-  placeholder:
-    name: Not implemented yet
+  install:
+    # The ref shows in the run list, so manual runs are told apart at a glance.
+    name: Install on kind (${{ inputs.exposure_mode || 'gateway' }}, ${{ inputs.ref || github.ref_name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - run: |
-          echo "This is the bootstrap stub on the default branch."
-          echo "Dispatch this workflow against the smoke test branch instead."
+      # Checking out an explicit ref takes the chart, devel/ and scripts/ from
+      # there, while the workflow itself is always the one being run. A ref
+      # without scripts/create_cluster.sh will fail at the cluster step.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Report what is being tested
+        run: |
+          {
+            echo "### Smoke test"
+            echo ""
+            echo "- ref: \`$(git rev-parse --abbrev-ref HEAD)\`"
+            echo "- commit: \`$(git rev-parse --short HEAD)\`"
+            echo "- chart version: \`$(grep '^version:' charts/penpot/Chart.yaml | awk '{print $2}')\`"
+            echo "- appVersion: \`$(grep '^appVersion:' charts/penpot/Chart.yaml | awk '{print $2}')\`"
+            echo "- exposure: \`$EXPOSURE_MODE\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Pick the values file
+        run: |
+          if [ "$EXPOSURE_MODE" = "gateway" ]; then
+            echo "VALUES=devel/penpot.values.gateway.yaml" >> "$GITHUB_ENV"
+          else
+            echo "VALUES=devel/penpot.values.yaml" >> "$GITHUB_ENV"
+          fi
+
+      - uses: azure/setup-helm@v5.0.1
+
+      # install_only: the cluster is created by scripts/create_cluster.sh, which
+      # is the same path a developer follows locally per devel/README.md. Letting
+      # the action create its own cluster would mean CI and local setups drifting.
+      - uses: helm/kind-action@v1.14.0
+        with:
+          install_only: true
+
+      # EXPOSURE_MODE is read by the script itself, which installs either
+      # ingress-nginx or the Gateway API CRDs plus Envoy Gateway.
+      - name: Create the cluster and its dependencies
+        run: ./scripts/create_cluster.sh
+
+      - name: Install the chart
+        run: |
+          helm install "$RELEASE" ./charts/penpot \
+            --namespace "$NAMESPACE" \
+            --values "$VALUES" \
+            --wait \
+            --timeout 15m
+
+      - name: Every component must roll out
+        run: |
+          set -euo pipefail
+          for deployment in $(kubectl get deployments -n "$NAMESPACE" \
+              -l app.kubernetes.io/instance="$RELEASE" -o name); do
+            echo "::group::$deployment"
+            kubectl rollout status "$deployment" -n "$NAMESPACE" --timeout=10m
+            echo "::endgroup::"
+          done
+
+      # Hits /readyz through the frontend, which proxies to the backend, so this
+      # covers the whole chain rather than just "the pods are running".
+      - name: Penpot must answer
+        run: helm test "$RELEASE" --namespace "$NAMESPACE" --logs
+
+      # helm test talks to the Service directly, so on its own it never exercises
+      # the HTTPRoute or the Ingress. This goes in through the front door.
+      - name: Traffic must reach Penpot through the exposure layer
+        run: |
+          set -euo pipefail
+          if [ "$EXPOSURE_MODE" = "gateway" ]; then
+            # forward_gateway.sh needs the Envoy service Envoy Gateway creates
+            # for this Gateway, so wait for that rather than for a status
+            # condition. kubectl wait with a selector errors out when nothing
+            # matches yet instead of waiting, hence the poll first.
+            selector="gateway.envoyproxy.io/owning-gateway-namespace=$NAMESPACE,gateway.envoyproxy.io/owning-gateway-name=penpot"
+            for _ in $(seq 1 60); do
+              if [ -n "$(kubectl get deploy -n envoy-gateway-system -l "$selector" \
+                   -o name 2>/dev/null)" ]; then
+                break
+              fi
+              sleep 5
+            done
+            if ! kubectl wait --for=condition=Available deploy \
+                 -n envoy-gateway-system -l "$selector" --timeout=300s; then
+              echo "::error::Envoy Gateway never produced a proxy for gateways/penpot"
+              kubectl get gatewayclass,gateway,httproute -A -o wide || true
+              kubectl describe gateway penpot -n "$NAMESPACE" || true
+              kubectl get pods -n envoy-gateway-system -o wide || true
+              kubectl logs -n envoy-gateway-system deploy/envoy-gateway --tail=100 || true
+              exit 1
+            fi
+            ./scripts/forward_gateway.sh &
+            forward_pid=$!
+            trap 'kill "$forward_pid" 2>/dev/null || true' EXIT
+            url=http://127.0.0.1:8888/
+          else
+            # devel/kind.config.yml maps host port 80 to the control plane node.
+            url=http://127.0.0.1/
+          fi
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error --max-time 10 \
+                 --header 'Host: penpot.example.com' "$url" >/dev/null; then
+              echo "ok: Penpot answered through $EXPOSURE_MODE"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::no answer through $EXPOSURE_MODE at $url"
+          kubectl get gateway,httproute,ingress -n "$NAMESPACE" -o wide || true
           exit 1
+
+      # NOTES.txt now branches on the values, so a broken condition would only
+      # surface on a user's install. Rendering both sides keeps that honest.
+      - name: The scaling warning must appear only when it applies
+        run: |
+          set -euo pipefail
+          # NOTES.txt is never part of `helm template` output: it is rendered and
+          # printed, not sent to Kubernetes, so --show-only cannot find it.
+          # --dry-run does print it. No error swallowing either: a render that
+          # fails must say so rather than silently yield an empty string.
+          render() {
+            helm install notes-check ./charts/penpot \
+              --namespace "$NAMESPACE" --values "$VALUES" --dry-run "$@"
+          }
+          quiet=$(render)
+          loud=$(render --set backend.replicaCount=2)
+          if grep -q "WARNING: more than one replica" <<<"$quiet"; then
+            echo "::error::the scaling warning fires on a default install"
+            exit 1
+          fi
+          if ! grep -q "WARNING: more than one replica" <<<"$loud"; then
+            echo "::error::the scaling warning does not fire when scaling the backend"
+            exit 1
+          fi
+          echo "ok: the warning fires only when it applies"
+
+      # An upgrade breaking is at least as likely as a fresh install breaking.
+      # The change is a rolling restart rather than a replica bump: the backend
+      # and frontend mount the assets PVC, which is ReadWriteOnce by default, so
+      # a second replica can land on the other node and stay Pending.
+      - name: Upgrade must work too
+        run: |
+          helm upgrade "$RELEASE" ./charts/penpot \
+            --namespace "$NAMESPACE" \
+            --values "$VALUES" \
+            --set-string backend.podAnnotations.smoke-test="$GITHUB_RUN_ID" \
+            --wait \
+            --timeout 15m
+          helm test "$RELEASE" --namespace "$NAMESPACE"
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          kubectl get all,pvc,ingress,gateway,httproute -n "$NAMESPACE" -o wide || true
+          kubectl describe pods -n "$NAMESPACE" || true
+          # The exposure layer lives in another namespace, and a failure there
+          # says nothing if only the penpot namespace is dumped.
+          kubectl get gatewayclass -o wide || true
+          kubectl describe gateway -n "$NAMESPACE" || true
+          kubectl get all -n envoy-gateway-system -o wide || true
+          kubectl describe pods -n envoy-gateway-system || true
+          kubectl logs -n envoy-gateway-system deploy/envoy-gateway --tail=200 || true
+          for pod in $(kubectl get pods -n "$NAMESPACE" -o name); do
+            echo "::group::logs $pod"
+            kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=200 || true
+            echo "::endgroup::"
+          done

--- a/charts/penpot/templates/NOTES.txt
+++ b/charts/penpot/templates/NOTES.txt
@@ -8,3 +8,47 @@
 
     $ helm status {{ .Release.Name }}
     $ helm get all {{ .Release.Name }}
+{{- /*
+Warn only when the combination actually bites: assets kept on a chart-managed
+ReadWriteOnce volume, the filesystem backend in use, and the backend or the
+frontend asked to run more than one pod. An existingClaim is left alone, since
+its access mode belongs to whoever created it.
+*/}}
+{{- $assetsOnRwo := and .Values.persistence.assets.enabled
+                       (not .Values.persistence.assets.existingClaim)
+                       (has "ReadWriteOnce" .Values.persistence.assets.accessModes)
+                       (eq .Values.config.objectsStorage.storageBackend "fs") }}
+{{- $scaledBackend := or (gt (int .Values.backend.replicaCount) 1) .Values.backend.autoscaling.hpa.enabled }}
+{{- $scaledFrontend := or (gt (int .Values.frontend.replicaCount) 1) .Values.frontend.autoscaling.hpa.enabled }}
+{{- if and $assetsOnRwo (or $scaledBackend $scaledFrontend) }}
+
+  WARNING: more than one replica with a ReadWriteOnce assets volume
+
+  The backend and the frontend both mount the assets PersistentVolumeClaim, and
+  it is ReadWriteOnce, so it can only attach to one node at a time. A second
+  replica scheduled onto another node will stay Pending, waiting for a volume it
+  cannot get. On a single-node cluster this works, and breaks the moment a
+  second node appears.
+
+  Either move the assets out of the cluster:
+
+    config:
+      objectsStorage:
+        storageBackend: s3
+        s3:
+          bucket: your-bucket
+          region: your-region
+    persistence:
+      assets:
+        enabled: false
+
+  or use a volume that several nodes can mount at once:
+
+    persistence:
+      assets:
+        accessModes:
+          - ReadWriteMany
+        storageClass: your-rwx-storage-class
+
+  See "Running more than one replica" in the chart README.
+{{- end }}

--- a/charts/penpot/templates/tests/test-connection.yaml
+++ b/charts/penpot/templates/tests/test-connection.yaml
@@ -1,0 +1,40 @@
+{{- /*
+Run with `helm test <release>`. Hits /readyz through the frontend service, which
+nginx proxies to the backend, so a pass means the whole chain is up: frontend
+serving, backend started and its database reachable.
+*/ -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "penpot.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "penpot.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  {{- with .Values.frontend.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: readyz
+      image: curlimages/curl:8.11.1
+      {{- with .Values.frontend.containerSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      args:
+        - --fail
+        - --silent
+        - --show-error
+        - --max-time
+        - "10"
+        - --retry
+        - "12"
+        - --retry-delay
+        - "5"
+        - --retry-connrefused
+        - http://{{ include "penpot.fullname" . }}:{{ .Values.frontend.service.port }}/readyz

--- a/devel/README.md
+++ b/devel/README.md
@@ -67,25 +67,11 @@ Choose one exposure mode:
   EXPOSURE_MODE=gateway ./scripts/create_cluster.sh
   ```
 
-- Create a local copy of the chart values:
+- Create a local copy of the chart values. `penpot.values.gateway.yaml` already
+  has ingress disabled, the gateway enabled and `publicUri` set to the port
+  `forward_gateway.sh` uses, so there is nothing to uncomment:
   ```shell
-  cp devel/penpot.values.yaml local.penpot.values.yaml
-  ```
-
-- Ensure the local values use:
-  ```yaml
-  config:
-    publicUri: "http://penpot.example.com:8888"
-  ingress:
-    enabled: false
-  gateway:
-    enabled: true
-    parentRefs:
-      - name: penpot
-        namespace: penpot
-        sectionName: http
-    hostnames:
-      - "penpot.example.com"
+  cp devel/penpot.values.gateway.yaml local.penpot.values.yaml
   ```
 
 - Install the chart:

--- a/devel/kind.config.yml
+++ b/devel/kind.config.yml
@@ -1,25 +1,40 @@
+---
+# Cluster used by scripts/create_cluster.sh, both locally and in CI.
+#
+# One control plane and one worker. Two nodes keep the topology honest — pods
+# land somewhere other than the node running the ingress controller, so anything
+# that quietly assumes co-location shows up here — while staying within what a
+# GitHub-hosted runner (4 vCPU, 16 GB) can hold alongside PostgreSQL, Valkey and
+# the four Penpot components.
+#
+# The control plane carries ingress-ready=true and the host port mappings
+# because the ingress-nginx manifest for kind selects that label and binds host
+# ports. In gateway mode nothing binds these; scripts/forward_gateway.sh
+# port-forwards Envoy instead.
+#
+# Note on scaling: the backend and the frontend both mount the assets PVC, which
+# defaults to ReadWriteOnce. On a multi-node cluster a second replica can be
+# scheduled onto the other node and stay Pending, because the volume is already
+# attached elsewhere. Set persistence.assets.accessModes to ReadWriteMany with
+# storage that supports it before scaling either of them.
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
-- role: control-plane
-  kubeadmConfigPatches:
-  - |
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
-  extraPortMappings:
-  - containerPort: 8080
-    hostPort: 8080
-    protocol: TCP
-  - containerPort: 80
-    hostPort: 80
-    protocol: TCP
-  - containerPort: 443
-    hostPort: 443
-    protocol: TCP
-- role: worker
-- role: worker
-- role: worker
-- role: worker
-- role: worker
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+      - containerPort: 8080
+        hostPort: 8080
+        protocol: TCP
+  - role: worker

--- a/devel/penpot.values.gateway.yaml
+++ b/devel/penpot.values.gateway.yaml
@@ -1,0 +1,43 @@
+---
+# Values for the Gateway API setup, the counterpart to penpot.values.yaml.
+#
+# Use with:
+#   EXPOSURE_MODE=gateway ./scripts/create_cluster.sh
+#   helm install penpot ./charts/penpot -n penpot -f devel/penpot.values.gateway.yaml
+#   ./scripts/forward_gateway.sh
+#
+# publicUri carries :8888 because forward_gateway.sh exposes Envoy on that port.
+config:
+  publicUri: "http://penpot.example.com:8888"
+  apiSecretKey: "my-secret-key"
+  flags: "enable-registration enable-login-with-password disable-email-verification enable-smtp disable-secure-session-cookies disable-onboarding enable-mcp"
+
+  postgresql:
+    host: "postgresql.penpot.svc.cluster.local"
+    port: 5432
+    database: "penpot"
+    username: "penpot"
+    password: "penpot"
+
+  redis:
+    host: "valkey.penpot.svc.cluster.local"
+    port: 6379
+    database: "0"
+
+persistence:
+  assets:
+    enabled: true
+
+ingress:
+  enabled: false
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: penpot
+      namespace: penpot
+      sectionName: http
+  hostnames:
+    - "penpot.example.com"
+  path: /
+  pathMatchType: PathPrefix


### PR DESCRIPTION
# Install the chart on a real cluster before releasing

## The problem

`release-charts` publishes on every push to `main`. Nothing between a merge and
Artifact Hub ever installs the chart. A template that renders but doesn't run —
a wrong image tag, a broken env var, a service pointing at the wrong port — gets
published and is found by whoever upgrades first.

## What changes

A smoke test that spins up a kind cluster, installs Penpot with PostgreSQL and
Valkey, waits for everything to come up, and checks that Penpot actually answers
over HTTP. It runs on pull requests, and `release.yml` now depends on it, so a
chart can't be published unless a real install succeeded.

It reuses what `devel/` already has — `scripts/create_cluster.sh` builds the
cluster and its dependencies, and the values come from `devel/`. CI follows the
same path a developer follows locally, so the two can't drift apart.

Runs take roughly 6–10 minutes, most of it pulling the Penpot images.

## What's in the PR

**1. A `helm test` hook.** `helm test penpot` now checks `/readyz` through the
frontend service. nginx proxies that to the backend, so a pass means the whole
chain works: frontend serving, backend started, database reachable. Users get it
too, for verifying their own installs.

**2. A note about scaling.** The backend and frontend both mount the assets
volume, which is `ReadWriteOnce` by default, so a second replica of either can be
scheduled onto another node and sit `Pending` forever waiting for a volume it
can't have. Nothing said so, while `values.yaml` offers `replicaCount` and an HPA
going up to 5. Adds a README section with the two ways around it (object storage,
or a ReadWriteMany volume) and a `NOTES.txt` warning that prints only when the
risky combination is actually present.

**3. The workflow.** Installs, waits for every deployment to roll out, runs
`helm test`, sends a request in through the exposure layer, then upgrades and
tests again — upgrades break at least as often as fresh installs. On failure it
dumps resources, describes and logs.

## Two smaller things

**Gateway API is the default exposure mode** for the test, with Ingress still
selectable on manual runs. (`create_cluster.sh` keeps defaulting to `ingress`
locally; only the workflow asks for `gateway`.) `kubernetes/ingress-nginx` was archived in March 2026
and no longer gets security patches, so the ingress path is the legacy one to
cover. The Ingress API itself is fine and the chart still supports it. Gateway
mode gets its own values file rather than asking people to uncomment a block,
which also simplifies the local instructions in `devel/README.md`.

**The kind cluster drops from six nodes to two.** Five workers cost real memory
on a GitHub runner and bought nothing. One worker still keeps pods off the node
running the ingress controller, which is the part worth keeping.